### PR TITLE
開始時のカメラ移動の処理とカメラ追尾の処理を追加した

### DIFF
--- a/Assets/Scenes/Play.unity
+++ b/Assets/Scenes/Play.unity
@@ -274,12 +274,11 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 179471744}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: -0.04, z: 0}
+  m_LocalPosition: {x: 0, y: -2.23, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1865460701}
-  - {fileID: 484747446}
   m_Father: {fileID: 0}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -357,6 +356,7 @@ GameObject:
   m_Component:
   - component: {fileID: 484747446}
   - component: {fileID: 484747445}
+  - component: {fileID: 484747447}
   - component: {fileID: 484747444}
   m_Layer: 0
   m_Name: Main Camera
@@ -424,13 +424,33 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 484747443}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0.04, z: -10}
+  m_LocalPosition: {x: 0, y: 0, z: -10}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 179471749}
-  m_RootOrder: 1
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &484747447
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 484747443}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 532e5190b7d237f4f9c20dd933b3f57e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  robot: {fileID: 179471750}
+  IsFollowRobot: 1
+  robotX: -5
+  robotMaxY: 2
+  robotMinY: -2
+  goalX: 5
+  initY: -2
+  cameraVelocity: 0.05
 --- !u!1 &885559085
 GameObject:
   m_ObjectHideFlags: 0
@@ -550,7 +570,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 885559085}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -0.05, y: -1.76, z: 0}
+  m_LocalPosition: {x: -1.24, y: -2.17, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -699,7 +719,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 0
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1303854462
 GameObject:
@@ -730,6 +750,24 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5100536abc5ac0848809c5ba0bffece0, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  cam: {fileID: 484747447}
+  robot: {fileID: 179471750}
+  _goalXPoint: 30
+  startAnimation:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1303854463}
+        m_TargetAssemblyTypeName: PlaySceneController, Assembly-CSharp
+        m_MethodName: GameStart
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!4 &1303854464
 Transform:
   m_ObjectHideFlags: 0
@@ -743,7 +781,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 2
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1716436268
 GameObject:

--- a/Assets/Scripts/Play/CameraController.cs
+++ b/Assets/Scripts/Play/CameraController.cs
@@ -1,0 +1,95 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+// カメラの位置を操作するComponent。
+[RequireComponent(typeof(Camera))]
+public class CameraController : MonoBehaviour
+{
+    [SerializeField] private MainRobot robot;
+    private Camera cam;
+    private Transform _transform;
+    private Transform robotTransform;
+
+    // カメラの追尾フラグ
+    [Header("ロボット追尾設定")]
+    public bool IsFollowRobot = false;
+    [Tooltip("ロボットのX軸の相対座標。0の場合画面中央にロボットが映る。")]
+    [SerializeField] private float robotX;
+    [Tooltip("ロボットのY軸の上端の相対座標。この値を超えないようにカメラが追尾する。")]
+    [SerializeField] private float robotMaxY;
+    [Tooltip("ロボットのY軸の下端の相対座標。この値を超えないようにカメラが追尾する。")]
+    [SerializeField] private float robotMinY;
+
+    [Header("開始時カメラ移動設定")]
+    private bool IsBeginning = false;
+    [Tooltip("ゴールのX軸の相対座標。開始時にゴールがこの座標に映るようにカメラを移動させる。")]
+    [SerializeField] private float goalX;
+    [Tooltip("ロボットのY軸の初期相対座標。開始時にY軸がこの座標に調整されます。")]
+    [SerializeField] private float initY;
+    [Tooltip("ステージを映すカメラの速度。この値が小さければカメラはゆっくりと動きます。")]
+    [SerializeField] private float cameraVelocity;
+    private float robotInitX;
+
+    // Start is called before the first frame update
+    void Awake()
+    {
+        cam = GetComponent<Camera>();
+        _transform = cam.transform;
+        robotTransform = robot.transform;
+    }
+
+    private void LateUpdate()
+    {
+        // 最初にカメラをゴールからロボットまで移動させる。
+        if (IsBeginning)
+        {
+            if (_transform.position.x < robotInitX - robotX)
+            {
+                endCameraBeginning();
+            }
+            else
+            {
+                _transform.position += Vector3.left * cameraVelocity;
+            }
+        }
+        // ロボットの位置に合わせてカメラを移動させる
+        else if (IsFollowRobot)
+        {
+            // ロボットの座標を取得
+            Vector3 robotPos = robotTransform.position;
+
+            // カメラの座標を調整する
+            Vector3 cameraPos = _transform.position;
+            cameraPos.x = robotPos.x - robotX;
+            float robotY = robotTransform.position.y;
+            if (cameraPos.y + robotMinY > robotY) cameraPos.y = robotY - robotMinY;
+            else if (cameraPos.y + robotMaxY < robotY) cameraPos.y = robotY - robotMaxY;
+            _transform.position = cameraPos;
+        }
+    }
+
+    // カメラの最初の移動モーションの準備をする
+    public void CameraReady()
+    {
+        IsBeginning = true;
+
+        // カメラの座標をゴール位置に調整する
+        Vector3 cameraPos = _transform.position;
+        cameraPos.x = PlaySceneController.Instance.GoalXPoint - goalX;
+        cameraPos.y = robotTransform.position.y - initY;
+        _transform.position = cameraPos;
+
+        // ロボットの初期X座標を取得する
+        robotInitX = robotTransform.position.x;
+    }
+
+    // カメラの移動が終わった際の処理
+    public void endCameraBeginning()
+    {
+        if (!IsBeginning) return;
+        IsBeginning = false;
+        IsFollowRobot = true;
+        PlaySceneController.Instance.endFirstCameraMove();
+    }
+}

--- a/Assets/Scripts/Play/CameraController.cs.meta
+++ b/Assets/Scripts/Play/CameraController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 532e5190b7d237f4f9c20dd933b3f57e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
#32 
プレイ画面管理にゴール位置の座標設定を追加。
開始時、設定されたゴール地点からロボットの位置までカメラが移動するようにした。
カメラが移動し終わったら、ロボットを追従するようにした。
その後、プレイ画面管理から開始アニメーション処理を呼び出すようにした（現状そこでゲーム開始処理を呼んでる）。
カメラはロボットを、指定のX座標で、ある程度Y座標は緩めな設定で追従するようにしている。