### PR TITLE
ステージDBからボタンを生成。画面遷移用の内部処理追加

### DIFF
--- a/Assets/Prefab/StageSelect/StageButton.prefab
+++ b/Assets/Prefab/StageSelect/StageButton.prefab
@@ -92,6 +92,7 @@ GameObject:
   - component: {fileID: 5393075291862608255}
   - component: {fileID: 5393075291862608254}
   - component: {fileID: 5393075291862608253}
+  - component: {fileID: 4867546816740186638}
   m_Layer: 5
   m_Name: StageButton
   m_TagString: Untagged
@@ -201,4 +202,28 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 5393075291862608254}
   m_OnClick:
     m_PersistentCalls:
-      m_Calls: []
+      m_Calls:
+      - m_Target: {fileID: 4867546816740186638}
+        m_TargetAssemblyTypeName: StageButton, Assembly-CSharp
+        m_MethodName: OnSelect
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &4867546816740186638
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5393075291862608243}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 41264056d9a22824380c22bfd1846c93, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/Scenes/Stage_Select.unity
+++ b/Assets/Scenes/Stage_Select.unity
@@ -123,108 +123,54 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
---- !u!1001 &169794759
-PrefabInstance:
+--- !u!1 &798936
+GameObject:
   m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 704889517}
-    m_Modifications:
-    - target: {fileID: 5393075291862608243, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_Name
-      value: StageButton (5)
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_RootOrder
-      value: 5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 180
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 180
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
---- !u!224 &169794760 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-  m_PrefabInstance: {fileID: 169794759}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 798937}
+  - component: {fileID: 798938}
+  m_Layer: 0
+  m_Name: StageSelectManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &798937
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 798936}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 542417457}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &798938
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 798936}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f08bd8a5030b64c44ae7edfcd119a9ec, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  stageDataBase: {fileID: 11400000, guid: 815d30dae568bed408682267f3d029af, type: 2}
+  scrollViewContent: {fileID: 704889516}
+  stageButtonBase: {fileID: 5393075291862608243, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
+  loadStage: {fileID: 540660131}
 --- !u!1 &190404189
 GameObject:
   m_ObjectHideFlags: 0
@@ -308,8 +254,8 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 1924406992}
   m_HandleRect: {fileID: 1924406991}
   m_Direction: 2
-  m_Value: 0.99999934
-  m_Size: 0.60514706
+  m_Value: 0
+  m_Size: 1
   m_NumberOfSteps: 0
   m_OnValueChanged:
     m_PersistentCalls:
@@ -364,6 +310,7 @@ GameObject:
   - component: {fileID: 540660130}
   - component: {fileID: 540660129}
   - component: {fileID: 540660128}
+  - component: {fileID: 540660131}
   m_Layer: 5
   m_Name: NextButton
   m_TagString: Untagged
@@ -434,7 +381,19 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 540660129}
   m_OnClick:
     m_PersistentCalls:
-      m_Calls: []
+      m_Calls:
+      - m_Target: {fileID: 540660131}
+        m_TargetAssemblyTypeName: LoadStage, Assembly-CSharp
+        m_MethodName: OnLoadStage
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!114 &540660129
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -473,11 +432,51 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 540660126}
   m_CullTransparentMesh: 1
---- !u!224 &678107880 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-  m_PrefabInstance: {fileID: 5393075291184903060}
+--- !u!114 &540660131
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 540660126}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9edd4c28a2ae23241ab1e678b94dba5d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  scenePrefix: Stage_
+--- !u!1 &542417456
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 542417457}
+  m_Layer: 0
+  m_Name: Script
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &542417457
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 542417456}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 798937}
+  m_Father: {fileID: 0}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &704889516
 GameObject:
   m_ObjectHideFlags: 0
@@ -507,13 +506,7 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 678107880}
-  - {fileID: 941304276}
-  - {fileID: 1142893940}
-  - {fileID: 1243182170}
-  - {fileID: 1491067241}
-  - {fileID: 169794760}
+  m_Children: []
   m_Father: {fileID: 1508819711}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -679,108 +672,6 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: -20, y: -20}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!1001 &941304275
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 704889517}
-    m_Modifications:
-    - target: {fileID: 5393075291862608243, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_Name
-      value: StageButton (1)
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_RootOrder
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 180
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 180
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
---- !u!224 &941304276 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-  m_PrefabInstance: {fileID: 941304275}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1026786971
 GameObject:
   m_ObjectHideFlags: 0
@@ -968,210 +859,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1055039867}
   m_CullTransparentMesh: 1
---- !u!1001 &1142893939
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 704889517}
-    m_Modifications:
-    - target: {fileID: 5393075291862608243, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_Name
-      value: StageButton (2)
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_RootOrder
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 180
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 180
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
---- !u!224 &1142893940 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-  m_PrefabInstance: {fileID: 1142893939}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &1243182169
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 704889517}
-    m_Modifications:
-    - target: {fileID: 5393075291862608243, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_Name
-      value: StageButton (3)
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_RootOrder
-      value: 3
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 180
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 180
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
---- !u!224 &1243182170 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-  m_PrefabInstance: {fileID: 1243182169}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1365632707
 GameObject:
   m_ObjectHideFlags: 0
@@ -1369,108 +1056,6 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: -20, y: -20}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!1001 &1491067240
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 704889517}
-    m_Modifications:
-    - target: {fileID: 5393075291862608243, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_Name
-      value: StageButton (4)
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_RootOrder
-      value: 4
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 180
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 180
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
---- !u!224 &1491067241 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-  m_PrefabInstance: {fileID: 1491067240}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1499356633
 GameObject:
   m_ObjectHideFlags: 0
@@ -2215,100 +1800,3 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2042658033}
   m_CullTransparentMesh: 1
---- !u!1001 &5393075291184903060
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 704889517}
-    m_Modifications:
-    - target: {fileID: 5393075291862608243, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_Name
-      value: StageButton
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_RootOrder
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 180
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 180
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5393075291862608252, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}

--- a/Assets/Scripts/StageSelect.meta
+++ b/Assets/Scripts/StageSelect.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 07f7f72d52eb6ce46bee1c6d6d6a5824
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/StageSelect/LoadStage.cs
+++ b/Assets/Scripts/StageSelect/LoadStage.cs
@@ -1,0 +1,24 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+// NextButtonにアタッチ
+public class LoadStage : MonoBehaviour
+{
+    [SerializeField] private string scenePrefix;
+
+    private int stageNum = 0;
+
+    public void SetStageNum(int stageNum)
+    {
+        this.stageNum = stageNum;
+    }
+
+    public void OnLoadStage()
+    {
+        Debug.Log($"Push loadStage : stageNum -> {stageNum}");
+        string sceneName = scenePrefix + stageNum;
+        SceneManager.LoadScene(sceneName);
+    }
+}

--- a/Assets/Scripts/StageSelect/LoadStage.cs.meta
+++ b/Assets/Scripts/StageSelect/LoadStage.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9edd4c28a2ae23241ab1e678b94dba5d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/StageSelect/Stage.cs
+++ b/Assets/Scripts/StageSelect/Stage.cs
@@ -1,0 +1,32 @@
+using UnityEngine;
+using System;
+
+[Serializable]
+public class Stage
+{
+    public Sprite thumbnail;
+    public float goalDistance;
+    public string memo;
+
+    private int stageNum;
+    private float bestDistance;
+    private float bestTime;
+
+    public int StageNum
+    {
+        get { return stageNum; }
+        set { stageNum = value; }
+    }
+
+    public float BestDicetance
+    {
+        get { return bestDistance; }
+        set { bestDistance = value; }
+    }
+
+    public float BestTime
+    {
+        get { return bestTime; }
+        set { bestTime = value; }
+    }
+}

--- a/Assets/Scripts/StageSelect/Stage.cs.meta
+++ b/Assets/Scripts/StageSelect/Stage.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f5988f34afe94a94c89ce80162f52d41
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/StageSelect/StageButton.cs
+++ b/Assets/Scripts/StageSelect/StageButton.cs
@@ -1,0 +1,25 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class StageButton : MonoBehaviour
+{
+    private Stage stage;
+    private StageSelectManager stageSelectManager;
+
+    public void Init
+    (
+        Stage stage, 
+        StageSelectManager stageSelectManager, 
+        int stageNum
+    ){
+        this.stage = stage;
+        this.stageSelectManager = stageSelectManager;
+        stage.StageNum = stageNum;
+    }
+
+    public void OnSelect()
+    {
+        stageSelectManager.SelectStage(stage);
+    }
+}

--- a/Assets/Scripts/StageSelect/StageButton.cs.meta
+++ b/Assets/Scripts/StageSelect/StageButton.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 41264056d9a22824380c22bfd1846c93
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/StageSelect/StageDataBase.cs
+++ b/Assets/Scripts/StageSelect/StageDataBase.cs
@@ -1,0 +1,9 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+[CreateAssetMenu(fileName = "StageDataBase", menuName = "ScriptableObjects/StageDataBase")]
+public class StageDataBase : ScriptableObject
+{
+    public List<Stage> stageList = new List<Stage>();
+}

--- a/Assets/Scripts/StageSelect/StageDataBase.cs.meta
+++ b/Assets/Scripts/StageSelect/StageDataBase.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 34405acf7054dd644a5912ada6bbf95c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/StageSelect/StageSelectManager.cs
+++ b/Assets/Scripts/StageSelect/StageSelectManager.cs
@@ -1,0 +1,41 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class StageSelectManager : MonoBehaviour
+{
+    [SerializeField] private StageDataBase stageDataBase;
+    [SerializeField] private GameObject scrollViewContent;
+    [SerializeField] private GameObject stageButtonBase;
+    [SerializeField] private LoadStage loadStage;
+
+    private void Start()
+    {
+        // ステージ選択ボタンを作成
+        int stageNum = 0;
+        foreach(Stage stage in stageDataBase.stageList)
+        {
+            // ステージ選択ボタンをプレハブから作成
+            GameObject stageButtonObj = Instantiate(stageButtonBase);
+
+            // コンポーネントは存在するか。無ければ追加
+            StageButton stageButton = stageButtonObj.GetComponent<StageButton>();
+            if (stageButton == null) stageButton = stageButtonObj.AddComponent<StageButton>();
+
+            // スクロールビューに追加
+            stageButton.transform.parent = scrollViewContent.transform;
+
+            // 初期化
+            stageButton.Init(stage, this, stageNum);
+
+            stageNum++;
+        }
+    }
+
+    public void SelectStage(Stage stage)
+    {
+        Debug.Log($"Push stageButton : stageNum -> {stage.StageNum}");
+        loadStage.SetStageNum(stage.StageNum);
+        /* サムネなどのUI処理 */
+    }
+}

--- a/Assets/Scripts/StageSelect/StageSelectManager.cs.meta
+++ b/Assets/Scripts/StageSelect/StageSelectManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f08bd8a5030b64c44ae7edfcd119a9ec
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/StageData.meta
+++ b/Assets/StageData.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 23efed6f89f23bb488169f65412b9ca5
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/StageData/StageDataBase.asset
+++ b/Assets/StageData/StageDataBase.asset
@@ -1,0 +1,33 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 34405acf7054dd644a5912ada6bbf95c, type: 3}
+  m_Name: StageDataBase
+  m_EditorClassIdentifier: 
+  stageList:
+  - thumbnail: {fileID: 10911, guid: 0000000000000000f000000000000000, type: 0}
+    goalDistance: 100
+    memo: TestData0
+  - thumbnail: {fileID: 10911, guid: 0000000000000000f000000000000000, type: 0}
+    goalDistance: 200
+    memo: TestData1
+  - thumbnail: {fileID: 10911, guid: 0000000000000000f000000000000000, type: 0}
+    goalDistance: 300
+    memo: TestData2
+  - thumbnail: {fileID: 10911, guid: 0000000000000000f000000000000000, type: 0}
+    goalDistance: 400
+    memo: TestData3
+  - thumbnail: {fileID: 10911, guid: 0000000000000000f000000000000000, type: 0}
+    goalDistance: 500
+    memo: TestData4
+  - thumbnail: {fileID: 10911, guid: 0000000000000000f000000000000000, type: 0}
+    goalDistance: 600
+    memo: TestData5

--- a/Assets/StageData/StageDataBase.asset.meta
+++ b/Assets/StageData/StageDataBase.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 815d30dae568bed408682267f3d029af
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UserSettings/Layouts/default-2021.dwlt
+++ b/UserSettings/Layouts/default-2021.dwlt
@@ -19,7 +19,7 @@ MonoBehaviour:
     width: 1366
     height: 685
   m_ShowMode: 4
-  m_Title: Project
+  m_Title: Console
   m_RootView: {fileID: 6}
   m_MinSize: {x: 875, y: 300}
   m_MaxSize: {x: 10000, y: 10000}
@@ -48,7 +48,7 @@ MonoBehaviour:
   m_MinSize: {x: 300, y: 200}
   m_MaxSize: {x: 24288, y: 16192}
   vertical: 0
-  controlID: 21
+  controlID: 42
 --- !u!114 &3
 MonoBehaviour:
   m_ObjectHideFlags: 52
@@ -111,7 +111,7 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 1
   m_Script: {fileID: 12006, guid: 0000000000000000e000000000000000, type: 0}
-  m_Name: ProjectBrowser
+  m_Name: ConsoleWindow
   m_EditorClassIdentifier: 
   m_Children: []
   m_Position:
@@ -120,14 +120,14 @@ MonoBehaviour:
     y: 309
     width: 1022
     height: 326
-  m_MinSize: {x: 231, y: 271}
-  m_MaxSize: {x: 10001, y: 10021}
-  m_ActualView: {fileID: 13}
+  m_MinSize: {x: 100, y: 100}
+  m_MaxSize: {x: 4000, y: 4000}
+  m_ActualView: {fileID: 18}
   m_Panes:
   - {fileID: 13}
   - {fileID: 18}
-  m_Selected: 0
-  m_LastSelected: 1
+  m_Selected: 1
+  m_LastSelected: 0
 --- !u!114 &6
 MonoBehaviour:
   m_ObjectHideFlags: 52
@@ -223,7 +223,7 @@ MonoBehaviour:
   m_MinSize: {x: 200, y: 200}
   m_MaxSize: {x: 16192, y: 16192}
   vertical: 1
-  controlID: 26
+  controlID: 43
 --- !u!114 &10
 MonoBehaviour:
   m_ObjectHideFlags: 52
@@ -248,7 +248,7 @@ MonoBehaviour:
   m_MinSize: {x: 200, y: 100}
   m_MaxSize: {x: 16192, y: 8096}
   vertical: 0
-  controlID: 27
+  controlID: 89
 --- !u!114 &11
 MonoBehaviour:
   m_ObjectHideFlags: 52
@@ -346,22 +346,22 @@ MonoBehaviour:
     m_SkipHidden: 0
     m_SearchArea: 1
     m_Folders:
-    - Assets/Prefab/StageSelect
+    - Assets/Scripts/StageSelect
     m_Globs: []
     m_OriginalText: 
   m_ViewMode: 1
-  m_StartGridSize: 64
+  m_StartGridSize: 16
   m_LastFolders:
-  - Assets/Prefab/StageSelect
-  m_LastFoldersGridSize: -1
+  - Assets/Scripts/StageSelect
+  m_LastFoldersGridSize: 16
   m_LastProjectPath: C:\Users\user\Desktop\cist\Kadai3\LT\geek\ROBOT-ROCKET
   m_LockTracker:
     m_IsLocked: 0
   m_FolderTreeState:
     scrollPos: {x: 0, y: 0}
-    m_SelectedIDs: 7a780000
-    m_LastClickedID: 30842
-    m_ExpandedIDs: 00000000326100004c61000000ca9a3b
+    m_SelectedIDs: a0600000
+    m_LastClickedID: 24736
+    m_ExpandedIDs: 000000005e6000007060000000ca9a3b
     m_RenameOverlay:
       m_UserAcceptedRename: 0
       m_Name: 
@@ -389,7 +389,7 @@ MonoBehaviour:
     scrollPos: {x: 0, y: 0}
     m_SelectedIDs: 
     m_LastClickedID: 0
-    m_ExpandedIDs: 0000000032610000
+    m_ExpandedIDs: 000000005e600000
     m_RenameOverlay:
       m_UserAcceptedRename: 0
       m_Name: 
@@ -433,7 +433,7 @@ MonoBehaviour:
       m_IsRenaming: 0
       m_OriginalEventType: 11
       m_IsRenamingFilename: 1
-      m_ClientGUIView: {fileID: 11}
+      m_ClientGUIView: {fileID: 5}
     m_CreateAssetUtility:
       m_EndAction: {fileID: 0}
       m_InstanceID: 0
@@ -442,9 +442,9 @@ MonoBehaviour:
       m_ResourceFile: 
     m_NewAssetIndexInList: -1
     m_ScrollPosition: {x: 0, y: 0}
-    m_GridSize: 64
+    m_GridSize: 16
   m_SkipHiddenPackages: 0
-  m_DirectoriesAreaWidth: 115
+  m_DirectoriesAreaWidth: 179
 --- !u!114 &14
 MonoBehaviour:
   m_ObjectHideFlags: 52
@@ -480,7 +480,7 @@ MonoBehaviour:
     m_ControlHash: -371814159
     m_PrefName: Preview_InspectorPreview
   m_LastInspectedObjectInstanceID: -1
-  m_LastVerticalScrollValue: 0
+  m_LastVerticalScrollValue: 609
   m_GlobalObjectId: 
   m_InspectorMode: 0
   m_LockTracker:
@@ -516,10 +516,10 @@ MonoBehaviour:
     m_SaveData: []
   m_SceneHierarchy:
     m_TreeViewState:
-      scrollPos: {x: 0, y: 0}
-      m_SelectedIDs: 
-      m_LastClickedID: 0
-      m_ExpandedIDs: 90faffff346000005060000092600000b6600000f4600000
+      scrollPos: {x: 0, y: 5}
+      m_SelectedIDs: 805f0000
+      m_LastClickedID: 24448
+      m_ExpandedIDs: 68edffff2cfbffff8c5f0000a45f0000e05f000014600000
       m_RenameOverlay:
         m_UserAcceptedRename: 0
         m_Name: 
@@ -790,9 +790,9 @@ MonoBehaviour:
   m_PlayAudio: 0
   m_AudioPlay: 0
   m_Position:
-    m_Target: {x: 2174.1199, y: 416.13016, z: -8.990856}
+    m_Target: {x: 1299.8529, y: 570.40704, z: -6.3899145}
     speed: 2
-    m_Value: {x: 2174.1199, y: 416.13016, z: -8.990856}
+    m_Value: {x: 1299.8529, y: 570.40704, z: -6.3899145}
   m_RenderMode: 0
   m_CameraMode:
     drawMode: 0
@@ -843,9 +843,9 @@ MonoBehaviour:
     speed: 2
     m_Value: {x: 0, y: 0, z: 0, w: 1}
   m_Size:
-    m_Target: 843.927
+    m_Target: 624.32025
     speed: 2
-    m_Value: 843.927
+    m_Value: 624.32025
   m_Ortho:
     m_Target: 1
     speed: 2


### PR DESCRIPTION
1. ステージをデータベースで管理可能にした
2. ステージ選択ボタンを押すと該当のステージ番号が遷移用のスクリプトに渡されるようにした
3. 決定ボタンで画面遷移の処理ができるようにした