### PR TITLE
アイテム性能にスプライトの設定項目を追加した

### DIFF
--- a/Assets/Editor/PartsPerformanceEditor.cs
+++ b/Assets/Editor/PartsPerformanceEditor.cs
@@ -58,6 +58,10 @@ public class PartsPerformanceEditor : Editor
         // UIä÷òAçÄñ⁄ÇÃï\é¶
         EditorGUILayout.LabelField("UIä÷òAçÄñ⁄");
         _target.partsName = EditorGUILayout.TextField(guiC_name, _target.partsName);
+        SerializedProperty partsSprite = serializedObject.FindProperty("partsSprite");
+        EditorGUILayout.PropertyField(partsSprite, true);
+        SerializedProperty iconSprite = serializedObject.FindProperty("iconSprite");
+        EditorGUILayout.PropertyField(iconSprite, true);
         SerializedProperty desc = serializedObject.FindProperty("description");
         EditorGUILayout.PropertyField(desc, true);
 

--- a/Assets/PartsPerformance/Parts/TestParts.asset
+++ b/Assets/PartsPerformance/Parts/TestParts.asset
@@ -23,4 +23,6 @@ MonoBehaviour:
   summonObjects:
   - {fileID: 9189922234437165178, guid: 22d0f9f0825994442ab35bce63a23d72, type: 3}
   partsName: "\u30C6\u30B9\u30C8\u30D1\u30FC\u30C4"
+  partsSprite: {fileID: -362770285, guid: 9683c8b471de41d4aaceed70fb114b1e, type: 3}
+  iconSprite: {fileID: -362770285, guid: 9683c8b471de41d4aaceed70fb114b1e, type: 3}
   description: "\u30C7\u30D0\u30C3\u30B0\u7528\u306E\u88C5\u5099\u30D1\u30FC\u30C4\u3067\u3059\u3002"

--- a/Assets/Scripts/Common/PartsPerformance.cs
+++ b/Assets/Scripts/Common/PartsPerformance.cs
@@ -21,6 +21,7 @@ public class PartsPerformance : ScriptableObject
         TestParts
     }
 
+    // 物理等プレイシーン関連
     public E_PartsID id;
     public E_ForceType forceType;
     public float m; // 質量
@@ -31,7 +32,12 @@ public class PartsPerformance : ScriptableObject
     public float cooltime;  // 効果終了後のクールタイム
     public List<SummonableObject> summonObjects = new List<SummonableObject>(); //召喚オブジェクトリスト
 
+    // UI関連項目
     public string partsName;    //アイテム名前
+    [Tooltip("装備時に表示される見た目。")]
+    public Sprite partsSprite;
+    [Tooltip("UI用にアイコンとして用いられる見た目。")]
+    public Sprite iconSprite;
     [Tooltip("説明文。UIでパーツ説明に用います。"), TextArea(3, 5)]
     public string description;  //アイテム説明
 }


### PR DESCRIPTION
#61 
アイテム性能から、パーツのスプライトの設定ができるようになりました。
テスト用パーツには大きさを無視した適当なスプライトが設定してあります。