### PR TITLE
パーツ使用終了時にパーツをパージするようにし、リプレイに登録する情報を増やした

### DIFF
--- a/Assets/Prefab/Play/RobotParts/PurgePartsPrefab.prefab
+++ b/Assets/Prefab/Play/RobotParts/PurgePartsPrefab.prefab
@@ -1,0 +1,108 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &3684927641593377400
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6705248386260435023}
+  - component: {fileID: 696483927225989134}
+  - component: {fileID: -3521977866789243238}
+  m_Layer: 0
+  m_Name: PurgePartsPrefab
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6705248386260435023
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3684927641593377400}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.75, y: 0.75, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &696483927225989134
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3684927641593377400}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 0
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!50 &-3521977866789243238
+Rigidbody2D:
+  serializedVersion: 4
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3684927641593377400}
+  m_BodyType: 0
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 1
+  m_LinearDrag: 0
+  m_AngularDrag: 0.05
+  m_GravityScale: 1
+  m_Material: {fileID: 0}
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 0
+  m_Constraints: 0

--- a/Assets/Prefab/Play/RobotParts/PurgePartsPrefab.prefab.meta
+++ b/Assets/Prefab/Play/RobotParts/PurgePartsPrefab.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: baec86ace4e2e144088405c6f765c859
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefab/Play/RobotParts/TestShadow.prefab
+++ b/Assets/Prefab/Play/RobotParts/TestShadow.prefab
@@ -102,11 +102,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ad7276a2c2a0c044580847a49efda31f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  purgePartsPrefab: {fileID: -3521977866789243238, guid: baec86ace4e2e144088405c6f765c859, type: 3}
   DestroyDuration: 2
   initMaxVelocity: 4
   initMinVelocity: 2
   initAngleRange: 120
-  initAngleVelocity: 0
+  initAngleVelocity: 180
 --- !u!114 &5364773325347998154
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Play.unity
+++ b/Assets/Scenes/Play.unity
@@ -403,11 +403,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ad7276a2c2a0c044580847a49efda31f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  purgePartsPrefab: {fileID: -3521977866789243238, guid: baec86ace4e2e144088405c6f765c859, type: 3}
   DestroyDuration: 2
   initMaxVelocity: 4
   initMinVelocity: 2
   initAngleRange: 120
-  initAngleVelocity: 0
+  initAngleVelocity: 180
 --- !u!1 &199935186
 GameObject:
   m_ObjectHideFlags: 0
@@ -659,6 +660,7 @@ MonoBehaviour:
     readyPartsList: []
     getPartsList: []
     usePartsFrame: 
+    endUsePartsFrame: 
     locateDatas: []
     forceDatas: []
     finishFrame: 0

--- a/Assets/Scripts/Play/MainRobot.cs
+++ b/Assets/Scripts/Play/MainRobot.cs
@@ -38,7 +38,11 @@ public class MainRobot : MonoBehaviour
         if (_status.IsFlying)
         {
             // アイテム使用終了判定
-            if (_status.IsUsingParts && !playPartsManager.IsUsingParts) _status.endUseParts();
+            if (_status.IsUsingParts && !playPartsManager.IsUsingParts)
+            {
+                _status.endUseParts();
+                replayInputManager.EndUseParts();
+            }
 
             // 仮の操作処理（アイテム使用）
             if (Input.GetKeyDown(KeyCode.Space))

--- a/Assets/Scripts/Play/PurgeManager.cs
+++ b/Assets/Scripts/Play/PurgeManager.cs
@@ -4,6 +4,9 @@ using UnityEngine;
 // ロボットパーツ使用後ののパージや、ゲームオーバー時のロボットのパージなどのパージオブジェクトを管理するComponent。
 public class PurgeManager : MonoBehaviour
 {
+    [Tooltip("パージするパーツの基礎となるプレファブ。スプライトのみを指定された場合、この見た目だけが変更される。")]
+    [SerializeField] private Rigidbody2D purgePartsPrefab;
+
     [Header("パージ時の初速設定")]
     [Tooltip("消滅するまでの時間")]
     [SerializeField] private float DestroyDuration = 2f;
@@ -16,20 +19,62 @@ public class PurgeManager : MonoBehaviour
     [Tooltip("回転の角速度")]
     [SerializeField] private float initAngleVelocity = 0f;
 
-    // パージするパーツリストに指定のデータを追加する
-    public void AddParts(List<Rigidbody2D> purgePartsGroup)
+    // パージするパーツリストに指定のデータをプレファブを指定して追加する
+    public void AddPartsByPrefab(List<Rigidbody2D> purgePartsGroup)
     {
         if (purgePartsGroup == null || purgePartsGroup.Count == 0) return;
         Vector3 position = transform.position;
         foreach (var prefab in purgePartsGroup)
         {
             // オブジェクトを生成し、初速度などを設定する
-            var rb = Instantiate(prefab, position + Vector3.back, Quaternion.identity);
-            var quat = Quaternion.Euler(0, 0, UnityEngine.Random.Range(0, initAngleRange) - initAngleRange * 0.5f);
-            rb.velocity = quat * Vector2.up * UnityEngine.Random.Range(initMinVelocity, initMaxVelocity);
-            rb.angularVelocity = initAngleVelocity;
-            // 指定秒数後に破棄する
-            Destroy(rb.gameObject, DestroyDuration);
+            var purgeParts = Instantiate(prefab, position + Vector3.back, Quaternion.identity);
+            // 初期設定を済ませる
+            SetFirstSettings(ref purgeParts);
         }
+    }
+    public void AddPartsByPrefab(Rigidbody2D purgePartsPrefab)
+    {
+        if (purgePartsPrefab == null ) return;
+        Vector3 position = transform.position;
+        // オブジェクトを生成し、初速度などを設定する
+        var purgeParts = Instantiate(purgePartsPrefab, position + Vector3.back, Quaternion.identity);
+        // 初期設定を済ませる
+        SetFirstSettings(ref purgeParts);
+    }
+
+    // パージするパーツリストに指定のデータをスプライトから構築して追加する
+    public void AddPartsBySprite(List<Sprite> purgePartsSprites)
+    {
+        if (!(purgePartsSprites?.Count > 0)) return;
+        Vector3 position = transform.position;
+        foreach(var sprite in purgePartsSprites)
+        {
+            // プレファブを生成し、見た目（スプライト）を指定されたものに変更する
+            var purgeParts = Instantiate(purgePartsPrefab, position + Vector3.back, Quaternion.identity);
+            purgeParts.GetComponent<SpriteRenderer>().sprite = sprite;
+            // 初期設定を済ませる
+            SetFirstSettings(ref purgeParts);
+        }
+    }
+    public void AddPartsBySprite(Sprite purgePartsSprite)
+    {
+        if (purgePartsSprite == null) return;
+        Vector3 position = transform.position;
+        // プレファブを生成し、見た目（スプライト）を指定されたものに変更する
+        var purgeParts = Instantiate(purgePartsPrefab, position + Vector3.back, Quaternion.identity);
+        purgeParts.GetComponent<SpriteRenderer>().sprite = purgePartsSprite;
+        // 初期設定を済ませる
+        SetFirstSettings(ref purgeParts);
+    }
+
+    // 生成したパージパーツオブジェクトに対して初期設定を行う
+    private void SetFirstSettings(ref Rigidbody2D purgeParts)
+    {
+        // 初速度を設定する
+        var quat = Quaternion.Euler(0, 0, Random.Range(0, initAngleRange) - initAngleRange * 0.5f);
+        purgeParts.velocity = quat * Vector2.up * Random.Range(initMinVelocity, initMaxVelocity);
+        purgeParts.angularVelocity = initAngleVelocity;
+        // 指定秒数後にオブジェクトを破棄する
+        Destroy(purgeParts.gameObject, DestroyDuration);
     }
 }

--- a/Assets/Scripts/Play/ReplayInputManager.cs
+++ b/Assets/Scripts/Play/ReplayInputManager.cs
@@ -36,6 +36,11 @@ public class ReplayInputManager : SingletonMonoBehaviourInSceneBase<ReplayInputM
     {
         _data.RegisterUseParts(frameCnt);
     }
+    // パーツの使用終了を記録（ロボットの状態管理が使用終了状態に遷移した際に呼び出し）
+    public void EndUseParts()
+    {
+        _data.RegisterEndUseParts(frameCnt);
+    }
     // パーツの獲得を記録（パーツ管理がパーツを獲得した際に呼び出し）
     public void GetParts(PartsInfo.PartsData data)
     {

--- a/Assets/Scripts/Play/RobotStatus.cs
+++ b/Assets/Scripts/Play/RobotStatus.cs
@@ -19,6 +19,8 @@ public class RobotStatus : MonoBehaviour
     private E_RobotStatus _status = E_RobotStatus.Ready;
     private int cooltime = 0;       // クールタイム
 
+    private Sprite usingPartsSprite = null;
+
     // ロボットの状態判定メソッド
     public bool IsPartsUsable => _status == E_RobotStatus.Fly;  // 装備パーツの使用可能判定
     public bool IsUsingParts => _status == E_RobotStatus.UseParts;  // パーツの使用中判定
@@ -76,6 +78,9 @@ public class RobotStatus : MonoBehaviour
         // アイテム使用状態へ状態遷移
         _status = E_RobotStatus.UseParts;
 
+        // パージする際に投げ出すパーツの見た目
+        usingPartsSprite = performance.partsSprite;
+
         // クールタイムを計算しておく
         cooltime = Mathf.RoundToInt(performance.cooltime / Time.fixedDeltaTime);
 
@@ -94,6 +99,13 @@ public class RobotStatus : MonoBehaviour
         // 状態遷移（クールタイムがあれば待機状態へ移行する）
         if (cooltime > 0) _status = E_RobotStatus.Cooldown;
         else _status = E_RobotStatus.Fly;
+
+        // 使用し終わったパーツをパージして投げ出す
+        if (usingPartsSprite != null)
+        {
+            _purgeManager.AddPartsBySprite(usingPartsSprite);
+            usingPartsSprite = null;
+        }
 
         // TODO：飛行orクールタイムのアニメーションに遷移する
     }
@@ -137,7 +149,7 @@ public class RobotStatus : MonoBehaviour
         _status = E_RobotStatus.EndFly;
 
         // TODO：ゲーム失敗時のアニメーションなどのロボット関係の処理
-        _purgeManager.AddParts(GameOverRobotPurgeData);
+        _purgeManager.AddPartsByPrefab(GameOverRobotPurgeData);
     }
 
     // カスタムメニューを開いた際に呼び出されるメソッド

--- a/Assets/Scripts/Play/ShadowRobot.cs
+++ b/Assets/Scripts/Play/ShadowRobot.cs
@@ -23,6 +23,7 @@ public class ShadowRobot : MonoBehaviour
     private PartsInfo.PartsData GetPartsData(int index) => index < readyPartsLength ? replayData.readyPartsList[index] : replayData.getPartsList[index - readyPartsLength].buildPartsData();
     private int partsNo = 0;    // 使用しているパーツの数
     private bool IsUsingParts => partsNo < readyPartsLength + getPartsLength && frameCnt >= replayData.usePartsFrame[partsNo];  // パーツを使用するフレームか判定
+    private bool IsEndUsing => partsNo - 1 < replayData.endUsePartsFrame.Count && frameCnt == replayData.endUsePartsFrame[partsNo - 1];
 
     // 位置情報関連
     private int transCnt = 0;   // 位置情報の参照インデックス
@@ -52,6 +53,7 @@ public class ShadowRobot : MonoBehaviour
         if (IsStart)
         {
             // パーツ使用モーション遷移の処理
+            if (_status.IsUsingParts && IsEndUsing) _status.endUseParts();
             if (IsUsingParts) UseParts();
 
             // 位置・速度などの定期的な修正
@@ -133,6 +135,8 @@ public class ShadowRobot : MonoBehaviour
         PartsPerformance performance = _playPartsManager.GetPerformance(data.id);
 
         // パーツの使用状態に移る（アニメーション遷移）
+        if (_status.IsUsingParts) _status.endUseParts();
+        _status.endCooltime();
         _status.startUseParts(performance, data);
 
         partsNo++;
@@ -177,5 +181,15 @@ public class ShadowRobot : MonoBehaviour
 
         // ロボットの重量を更新する
         _move.SetWeight(_move.GetWeight() + sumWeight);
+    }
+
+    // パーツの使用終了をRobotStatusに伝える
+    private IEnumerator CallUsePartsEnd(float time)
+    {
+        yield return new WaitForSeconds(time);
+        if (_status.IsUsingParts)
+        {
+            _status.endUseParts();
+        }
     }
 }

--- a/Assets/Scripts/Play/Values/ReplayData.cs
+++ b/Assets/Scripts/Play/Values/ReplayData.cs
@@ -15,6 +15,8 @@ public class ReplayData
     public List<GetPartsData> getPartsList = new List<GetPartsData>();
     // アイテムの使用タイミングのリスト
     public List<int> usePartsFrame = new List<int>();
+    // アイテムの使用終了タイミングのリスト
+    public List<int> endUsePartsFrame = new List<int>();
 
     // ロボットの座標データのリスト
     public List<LocateData> locateDatas = new List<LocateData>();
@@ -33,6 +35,7 @@ public class ReplayData
         readyPartsList = new List<PartsInfo.PartsData>(PartsInfo.Instance.GetPartsList());
         getPartsList.Clear();
         usePartsFrame.Clear();
+        endUsePartsFrame.Clear();
         locateDatas.Clear();
         forceDatas.Clear();
         finishFrame = 0;
@@ -42,6 +45,11 @@ public class ReplayData
     public void RegisterUseParts(int frame)
     {
         usePartsFrame.Add(frame);
+    }
+    // パーツの使用終了タイミングを記録する
+    public void RegisterEndUseParts(int frame)
+    {
+        endUsePartsFrame.Add(frame);
     }
     // 獲得したパーツデータを記録する
     public void RegisterGetParts(int frame, PartsPerformance.E_PartsID id, float Angle)


### PR DESCRIPTION
#62 
パーツ使用終了時に設定したPrefabの画像をパーツの画像に変更し、PurgeManagerへ渡してパージするようにした。
その際シャドウの動きが多少おかしいと気付いたので、とりあえずリプレイで収集する情報を一つ増やして対応した。