### PR TITLE
カスタムPrefabをPlayシーンに配置し、シャドウの動作を安定化した

### DIFF
--- a/Assets/Scenes/Play.unity
+++ b/Assets/Scenes/Play.unity
@@ -216,6 +216,58 @@ PrefabInstance:
       propertyPath: m_Layer
       value: 5
       objectReference: {fileID: 0}
+    - target: {fileID: 376683007813691299, guid: a788f306020840147b042e3fa37baee5, type: 3}
+      propertyPath: m_Delegates.Array.data[0].callback.m_PersistentCalls.m_Calls.Array.size
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 376683007813691299, guid: a788f306020840147b042e3fa37baee5, type: 3}
+      propertyPath: m_Delegates.Array.data[0].callback.m_PersistentCalls.m_Calls.Array.data[1].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 376683007813691299, guid: a788f306020840147b042e3fa37baee5, type: 3}
+      propertyPath: m_Delegates.Array.data[0].callback.m_PersistentCalls.m_Calls.Array.data[2].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 376683007813691299, guid: a788f306020840147b042e3fa37baee5, type: 3}
+      propertyPath: m_Delegates.Array.data[0].callback.m_PersistentCalls.m_Calls.Array.data[1].m_Target
+      value: 
+      objectReference: {fileID: 1902095544}
+    - target: {fileID: 376683007813691299, guid: a788f306020840147b042e3fa37baee5, type: 3}
+      propertyPath: m_Delegates.Array.data[0].callback.m_PersistentCalls.m_Calls.Array.data[2].m_Target
+      value: 
+      objectReference: {fileID: 1303854463}
+    - target: {fileID: 376683007813691299, guid: a788f306020840147b042e3fa37baee5, type: 3}
+      propertyPath: m_Delegates.Array.data[0].callback.m_PersistentCalls.m_Calls.Array.data[1].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 376683007813691299, guid: a788f306020840147b042e3fa37baee5, type: 3}
+      propertyPath: m_Delegates.Array.data[0].callback.m_PersistentCalls.m_Calls.Array.data[2].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 376683007813691299, guid: a788f306020840147b042e3fa37baee5, type: 3}
+      propertyPath: m_Delegates.Array.data[0].callback.m_PersistentCalls.m_Calls.Array.data[1].m_MethodName
+      value: ClosePanel
+      objectReference: {fileID: 0}
+    - target: {fileID: 376683007813691299, guid: a788f306020840147b042e3fa37baee5, type: 3}
+      propertyPath: m_Delegates.Array.data[0].callback.m_PersistentCalls.m_Calls.Array.data[2].m_MethodName
+      value: CloseCustomMenu
+      objectReference: {fileID: 0}
+    - target: {fileID: 376683007813691299, guid: a788f306020840147b042e3fa37baee5, type: 3}
+      propertyPath: m_Delegates.Array.data[0].callback.m_PersistentCalls.m_Calls.Array.data[1].m_TargetAssemblyTypeName
+      value: UIOpener, Assembly-CSharp
+      objectReference: {fileID: 0}
+    - target: {fileID: 376683007813691299, guid: a788f306020840147b042e3fa37baee5, type: 3}
+      propertyPath: m_Delegates.Array.data[0].callback.m_PersistentCalls.m_Calls.Array.data[2].m_TargetAssemblyTypeName
+      value: PlaySceneController, Assembly-CSharp
+      objectReference: {fileID: 0}
+    - target: {fileID: 376683007813691299, guid: a788f306020840147b042e3fa37baee5, type: 3}
+      propertyPath: m_Delegates.Array.data[0].callback.m_PersistentCalls.m_Calls.Array.data[1].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
+    - target: {fileID: 376683007813691299, guid: a788f306020840147b042e3fa37baee5, type: 3}
+      propertyPath: m_Delegates.Array.data[0].callback.m_PersistentCalls.m_Calls.Array.data[2].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
     - target: {fileID: 376683007813691326, guid: a788f306020840147b042e3fa37baee5, type: 3}
       propertyPath: m_SortingLayer
       value: 2
@@ -368,6 +420,10 @@ PrefabInstance:
       propertyPath: m_SortingLayerID
       value: 1146199475
       objectReference: {fileID: 0}
+    - target: {fileID: 7032684976403692476, guid: a788f306020840147b042e3fa37baee5, type: 3}
+      propertyPath: IsDestroyAfterUpdate
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 7032684976403692477, guid: a788f306020840147b042e3fa37baee5, type: 3}
       propertyPath: m_Layer
       value: 5
@@ -472,7 +528,13 @@ PrefabInstance:
       propertyPath: m_Layer
       value: 5
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 7032684976866807339, guid: a788f306020840147b042e3fa37baee5, type: 3}
+    - {fileID: 7032684977288661731, guid: a788f306020840147b042e3fa37baee5, type: 3}
+    - {fileID: 7032684977123255874, guid: a788f306020840147b042e3fa37baee5, type: 3}
+    - {fileID: 7032684975836016288, guid: a788f306020840147b042e3fa37baee5, type: 3}
+    - {fileID: 7032684977699049191, guid: a788f306020840147b042e3fa37baee5, type: 3}
+    - {fileID: 376683007813691325, guid: a788f306020840147b042e3fa37baee5, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: a788f306020840147b042e3fa37baee5, type: 3}
 --- !u!1 &166251956
 GameObject:
@@ -1890,7 +1952,7 @@ GameObject:
   - component: {fileID: 990573747}
   - component: {fileID: 990573748}
   - component: {fileID: 990573746}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: UnderStageLine
   m_TagString: GameOverCollider
   m_Icon: {fileID: 0}
@@ -2424,6 +2486,30 @@ MonoBehaviour:
       - m_Target: {fileID: 179471759}
         m_TargetAssemblyTypeName: FollowerManager, Assembly-CSharp
         m_MethodName: DestroyAllFollowers
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 866832308}
+        m_TargetAssemblyTypeName: ReplayInputManager, Assembly-CSharp
+        m_MethodName: Save
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 1902095544}
+        m_TargetAssemblyTypeName: UIOpener, Assembly-CSharp
+        m_MethodName: OpenPanel
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -3567,6 +3653,7 @@ GameObject:
   - component: {fileID: 1902095541}
   - component: {fileID: 1902095543}
   - component: {fileID: 1902095542}
+  - component: {fileID: 1902095544}
   m_Layer: 5
   m_Name: CustomPanel
   m_TagString: Untagged
@@ -3633,6 +3720,18 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1902095540}
   m_CullTransparentMesh: 1
+--- !u!114 &1902095544
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1902095540}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 94cd26f4abbb2be43a7cfc442a28c05c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1944738011
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Custom/Queue.cs
+++ b/Assets/Scripts/Custom/Queue.cs
@@ -28,7 +28,9 @@ public class Queue : MonoBehaviour{
 
     public GameObject custom_panel;
 
-    void Start(){
+    [SerializeField] private bool IsDestroyAfterUpdate = true;
+
+    void Awake(){
 
         _partsInfo = PartsInfo.Instance;
         myList=_partsInfo.GetPartsList();
@@ -40,7 +42,7 @@ public class Queue : MonoBehaviour{
         //myListをGameObjectの配列に変形
         for(int i=0;i<myList.Count;i++){
             
-            GameObject newitem=Instantiate(item) as GameObject;
+            GameObject newitem=Instantiate(item, custom_panel.transform) as GameObject;
             SpriteRenderer newitem_renderer=newitem.GetComponent<SpriteRenderer>();
             newitem_renderer.sprite=_data.getData(myList[i].id).partsSprite;
             Items newitem_script=newitem.GetComponent<Items>();
@@ -56,16 +58,14 @@ public class Queue : MonoBehaviour{
                 
             }
 
-            newitem.transform.parent=custom_panel.transform;
-            newitem.transform.position=new Vector3(3.5f,0f,0f);
+            newitem.transform.localPosition=new Vector3(3.5f,0f,0f);
 
-            GameObject newicon=Instantiate(icon) as GameObject;
+            GameObject newicon=Instantiate(icon, transform) as GameObject;
             Icon_inqueue newicon_script=newicon.GetComponent<Icon_inqueue>();
             newicon_script.mynumber=testlist.Count;
             newicon_script.id=myList[i].id;
             SpriteRenderer newicon_renderer=newicon.GetComponent<SpriteRenderer>();
             newicon_renderer.sprite=_data.getData(myList[i].id).iconSprite;
-            newicon.transform.parent=custom_panel.transform;
 
             if(icon_list.Count==0){
 
@@ -74,12 +74,12 @@ public class Queue : MonoBehaviour{
             }else{
             
                 GameObject last_icon=icon_list[icon_list.Count-1];
-                Vector2 last_position=last_icon.transform.position;
+                Vector2 last_position=last_icon.transform.localPosition;
                 draw_position=last_position.y-=1.0f;
 
             }
 
-            newicon.transform.position=new Vector2(7.6f,draw_position);
+            newicon.transform.localPosition=new Vector2(7.6f,draw_position);
 
             testlist.Add(newitem);
             icon_list.Add(newicon);
@@ -124,7 +124,7 @@ public class Queue : MonoBehaviour{
 
         Custom_button.panel_on=false;
 
-        Destroy(custom_panel);
+        if (IsDestroyAfterUpdate) Destroy(custom_panel);
 
         //テスト用
         //SceneManager.LoadScene("Play");

--- a/Assets/Scripts/Play/FollowerManager.cs
+++ b/Assets/Scripts/Play/FollowerManager.cs
@@ -58,7 +58,7 @@ public class FollowerManager : MonoBehaviour
     // 獲得したパーツのアイコンを増やす処理
     public void GetParts(PartsInfo.PartsData data)
     {
-        var follower = Instantiate(followPrefab, transform.position, Quaternion.identity);
+        var follower = Instantiate(followPrefab, transform.position, Quaternion.identity, transform);
         follower.SetSprite(PlayPartsManager.Instance.GetPerformance(data.id).iconSprite);
         if (followers.Count == 0) follower.target = transform;
         else follower.target = followers[^1].transform;

--- a/Assets/Scripts/Play/Replay/ReplayInputManager.cs
+++ b/Assets/Scripts/Play/Replay/ReplayInputManager.cs
@@ -74,7 +74,6 @@ public class ReplayInputManager : SingletonMonoBehaviourInSceneBase<ReplayInputM
         {
             // リプレイモードではない時は、取得したデータを自動で保存させてみる
             _data.RegisterResult(frameCnt, _sceneController.Score);
-            Save();
         }
         IsGamePlay = false;
         NoMemoryMode = false;

--- a/Assets/Scripts/Play/Replay/ReplayPlayer.cs
+++ b/Assets/Scripts/Play/Replay/ReplayPlayer.cs
@@ -154,7 +154,7 @@ public class ReplayPlayer : MonoBehaviour
         IsStartUsing = _currentPartsNo < _startUseLength && frameCnt == _replayData.usePartsFrame[_currentPartsNo];
         IsEndUsing = _currentPartsNo != 0 && _currentPartsNo - 1 < _endUseLength && frameCnt == _replayData.endUsePartsFrame[_currentPartsNo - 1];
         IsTransUpdate = _currentTransNo < _transformLength && frameCnt >= _replayData.locateDatas[_currentTransNo].frame;
-        getPartsData = _replayData.getPartsList.FindAll(data => frameCnt >= data.frame).ConvertAll(data => data.buildPartsData());
+        getPartsData = _replayData.getPartsList.FindAll(data => frameCnt == data.frame).ConvertAll(data => data.buildPartsData());
         addForceList = _replayData.forceDatas.FindAll(data => frameCnt == data.frame);
         frameCnt++;
     }

--- a/Assets/Scripts/Play/UI/GameEndPanel.cs
+++ b/Assets/Scripts/Play/UI/GameEndPanel.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 using UnityEngine.UI;
 
 // ゲーム終了時に表示されるウィンドウUIを管理するComponent
-public class GameEndPanel : MonoBehaviour
+public class GameEndPanel : UIOpener
 {
     [SerializeField] private Text resultText;
     [SerializeField] private Text scoreText;
@@ -26,11 +26,6 @@ public class GameEndPanel : MonoBehaviour
         PlaySceneController _playSceneController = PlaySceneController.Instance;
         resultText.text = resultMessage;
         scoreText.text = "Score：" + _playSceneController.Score + "\nHigh Score：???";
-        gameObject.SetActive(true);
-    }
-    // パネルを閉じる
-    public void ClosePanel()
-    {
-        gameObject.SetActive(false);
+        base.OpenPanel();
     }
 }

--- a/Assets/Scripts/Play/UI/UIOpener.cs
+++ b/Assets/Scripts/Play/UI/UIOpener.cs
@@ -1,0 +1,19 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+// UIウィンドウを開いたり閉じたりするComponent。
+public class UIOpener : MonoBehaviour
+{
+    // パネルを開く（有効化する）
+    public virtual void OpenPanel()
+    {
+        gameObject.SetActive(true);
+    }
+
+    // パネルを閉じる（無効化する）
+    public virtual void ClosePanel()
+    {
+        gameObject.SetActive(false);
+    }
+}

--- a/Assets/Scripts/Play/UI/UIOpener.cs.meta
+++ b/Assets/Scripts/Play/UI/UIOpener.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 94cd26f4abbb2be43a7cfc442a28c05c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Play/Values/ReplayData.cs
+++ b/Assets/Scripts/Play/Values/ReplayData.cs
@@ -27,6 +27,20 @@ public class ReplayData
     public int finishFrame = 0;
     public float score = 0f;
 
+    public ReplayData() { }
+    // コピーコンストラクタ
+    public ReplayData(ReplayData originalData)
+    {
+        StageNum = originalData.StageNum;
+        readyPartsList = new List<PartsInfo.PartsData>(originalData.readyPartsList);
+        getPartsList = new List<GetPartsData>(originalData.getPartsList);
+        usePartsFrame = new List<int>(originalData.usePartsFrame);
+        endUsePartsFrame = new List<int>(originalData.endUsePartsFrame);
+        locateDatas = new List<LocateData>(originalData.locateDatas);
+        forceDatas = new List<ForceData>(originalData.forceDatas);
+        finishFrame = originalData.finishFrame;
+        score = originalData.score;
+    }
 
     // データを初期化して、準備したパーツデータを読み込む
     public void ReadyPartsInfo(int StageNum)

--- a/Assets/Scripts/Play/Values/ReplayDatas.cs
+++ b/Assets/Scripts/Play/Values/ReplayDatas.cs
@@ -1,8 +1,10 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
 // リプレイデータをまとめて保管するシングルトン
+[Serializable]
 public class ReplayDatas : SavableSingletonBase<ReplayDatas>
 {
     // リプレイデータのリスト
@@ -18,7 +20,7 @@ public class ReplayDatas : SavableSingletonBase<ReplayDatas>
         List<ReplayData> nowDataList = GetStageReplay(data.StageNum);
         if (nowDataList?.Count > 4) datas.Remove(nowDataList[0]);
 
-        datas.Add(data);
+        datas.Add(new ReplayData(data));
     }
     // 指定のステージのリプレイデータを取得する
     public List<ReplayData> GetStageReplay(int StageNum)


### PR DESCRIPTION
#116 
プレイシーン上にカスタム画面Prefabを設置し、カスタム画面呼び出しメソッドから呼び出せるようにした。
また、シャドウの動作を安定化した（パーツ獲得時の追従アイコンの修正、リプレイデータ保存時のデータコピーなど）

尚、カスタム画面のスクリプトで相対座標にし忘れていたものがあったので直した。
またプレイシーンではUIを破棄せず非表示にするだけなので、破棄処理を設定で無効化できるようにした。