### PR TITLE
SingletonDontDestroyを追加

### DIFF
--- a/Assets/Scripts/Common/SingletonDontDestroy.cs
+++ b/Assets/Scripts/Common/SingletonDontDestroy.cs
@@ -1,0 +1,25 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class  SingletonDontDestroy<U> 
+            : SingletonMonoBehaviourInSceneBase<SingletonDontDestroy<U>> 
+    where U : SingletonMonoBehaviourInSceneBase<SingletonDontDestroy<U>>
+{
+    public static new U Instance { get; private set; }
+
+    // Start is called before the first frame update
+    protected override void Awake()
+    {
+        if (null != Instance && Instance != this)
+        {
+            Destroy(this.gameObject);
+        }
+
+        Instance = this as U;
+
+        base.Awake();
+
+        DontDestroyOnLoad(this);
+    }
+}

--- a/Assets/Scripts/Common/SingletonDontDestroy.cs.meta
+++ b/Assets/Scripts/Common/SingletonDontDestroy.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b4a1368591c4d8e43a9ca8d02ead3bfc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/StageSelect/StageSelectGlobal.cs
+++ b/Assets/Scripts/StageSelect/StageSelectGlobal.cs
@@ -1,0 +1,14 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class StageSelectGlobal : SingletonDontDestroy<StageSelectGlobal>
+{
+    private int stageNum = -1;
+
+    public int StageNum
+    {
+        get { return stageNum; }
+        set { stageNum = value; }
+    }
+}

--- a/Assets/Scripts/StageSelect/StageSelectGlobal.cs.meta
+++ b/Assets/Scripts/StageSelect/StageSelectGlobal.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8cb86c5aa8cd703438b482abdd1c1703
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
SingletonMono~クラスを継承して作成
SingletonDontDestroyを継承するとシーン遷移で破棄されないゲームオブジェクトを作ることができる