### PR TITLE
ステージセレクト画面からプレイシーンへ値を渡せるようになった

### DIFF
--- a/Assets/Scenes/Stage_Select.unity
+++ b/Assets/Scenes/Stage_Select.unity
@@ -172,6 +172,50 @@ MonoBehaviour:
   scrollViewContent: {fileID: 704889516}
   numberSelectButtonBase: {fileID: 5393075291862608243, guid: 0378c678b974eb84987a05c25fcf224f, type: 3}
   loadStage: {fileID: 540660131}
+--- !u!1 &64745540
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 64745542}
+  - component: {fileID: 64745541}
+  m_Layer: 0
+  m_Name: StageSelectGlobal
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &64745541
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 64745540}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8cb86c5aa8cd703438b482abdd1c1703, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &64745542
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 64745540}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &190404189
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Play/PlaySceneController.cs
+++ b/Assets/Scripts/Play/PlaySceneController.cs
@@ -48,6 +48,8 @@ public class PlaySceneController : SingletonMonoBehaviourInSceneBase<PlaySceneCo
 
     private IEnumerator hitStopCoroutine;
 
+    private Stage _currentStage = new Stage();
+    public Stage CurrentStage { get { return _currentStage; } private set { _currentStage = value; } }
 
 
     protected override void Awake()
@@ -58,6 +60,7 @@ public class PlaySceneController : SingletonMonoBehaviourInSceneBase<PlaySceneCo
         cam.CameraReady();
 
         // (必要であればここで暗転の解除など)
+        InitStageInfo();
     }
 
     // 最初のカメラ移動が終わった際に呼び出されるメソッド
@@ -271,6 +274,13 @@ public class PlaySceneController : SingletonMonoBehaviourInSceneBase<PlaySceneCo
         if (time > 0) yield return new WaitForSeconds(time);
         action();
         yield break;
+    }
+    // ステージ情報を受け取るメソッド
+    private void InitStageInfo()
+    {
+        CurrentStage = StageSelectGlobal.Instance.Stage;
+        StageNum = CurrentStage.StageNum;
+        /* ゴール座標はどうするか */
     }
 
     // シーンの処理場面を示す列挙型

--- a/Assets/Scripts/StageSelect/LoadStage.cs
+++ b/Assets/Scripts/StageSelect/LoadStage.cs
@@ -10,10 +10,12 @@ public class LoadStage : MonoBehaviour
     [SerializeField] private string scenePrefix;
 
     private int stageNum = -1;
+    private Stage stage = new Stage();
 
-    public void SetStageNum(int stageNum)
+    public void SetStageNum(Stage stage)
     {
-        this.stageNum = stageNum;
+        this.stageNum = stage.StageNum;
+        this.stage = stage;
     }
 
     public void OnLoadStage()
@@ -21,6 +23,7 @@ public class LoadStage : MonoBehaviour
         Debug.Log($"Push loadStage : stageNum -> {stageNum}");
         Debug.Log("OnLoadStage : Debug—pˆ—");
         string sceneName = scenePrefix + stageNum;
+        StageSelectGlobal.Instance.Stage = stage;
         sceneName = "Play";
         SceneManager.LoadScene(sceneName);
     }

--- a/Assets/Scripts/StageSelect/StageSelectGlobal.cs
+++ b/Assets/Scripts/StageSelect/StageSelectGlobal.cs
@@ -1,14 +1,15 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using System;
 
 public class StageSelectGlobal : SingletonDontDestroy<StageSelectGlobal>
 {
-    private int stageNum = -1;
+    private Stage stage = new Stage();
 
-    public int StageNum
+    public Stage Stage
     {
-        get { return stageNum; }
-        set { stageNum = value; }
+        get { return stage; }
+        set { stage = value; }
     }
 }

--- a/Assets/Scripts/StageSelect/StageSelectManager.cs
+++ b/Assets/Scripts/StageSelect/StageSelectManager.cs
@@ -65,7 +65,7 @@ public class StageSelectManager : MonoBehaviour
     public void SelectStage(Stage stage)
     {
         Debug.Log($"Push stageButton : stageNum -> {stage.StageNum}");
-        loadStage.SetStageNum(stage.StageNum);
+        loadStage.SetStageNum(stage);
         uIManager.SelectStage(stage);
     }
 }


### PR DESCRIPTION
【作業概要】
・ステージセレクト画面からStageSelectGlobalクラスを通してステージ情報を渡せるようになった。
・PlaySceneControllerにStageNumやStageを格納するメソッドを追加

【問題点】
・私の編集により改行コードが混在してしまった