### PR TITLE
リプレイからのパーツの参照読み込みを直し、一応PartsDataのコピーコンストラクタを用意した

### DIFF
--- a/Assets/Scripts/Common/PartsInfo.cs
+++ b/Assets/Scripts/Common/PartsInfo.cs
@@ -29,6 +29,11 @@ public class PartsInfo : SavableSingletonBase<PartsInfo>
     [Serializable]
     public class PartsData
     {
+        public PartsData() { }
+        public PartsData(PartsData data) {
+            id = data.id;
+            angle = data.angle;
+        }
         public PartsPerformance.E_PartsID id;
         public float angle;
     }

--- a/Assets/Scripts/Play/MainRobot.cs
+++ b/Assets/Scripts/Play/MainRobot.cs
@@ -104,7 +104,7 @@ public class MainRobot : MonoBehaviour
             _player.LoadReplayData(_useReplayData);
 
             // 用意してきたパーツをリプレイのものに変更
-            partsInfo.partsList = _player.InitialPartsDatas;
+            partsInfo.partsList = new List<PartsInfo.PartsData>(_player.InitialPartsDatas);
 
             // スコアをリプレイのものに変更
             playSceneController.Score = _useReplayData.score;


### PR DESCRIPTION
#172 
リプレイでパーツを使用すると参照先のデータまで消費されるバグを直した。
リプレイが保存されないバグは、デバッグモードでMainRobotのインスペクタを開いた際に発生する模様なので放置。