### PR TITLE
高さによるゲームオーバー判定機能を追加し、下の当たり判定を削除した

### DIFF
--- a/Assets/Prefab/Play/PlaySystem.prefab
+++ b/Assets/Prefab/Play/PlaySystem.prefab
@@ -976,7 +976,7 @@ Transform:
   - {fileID: 5707609332043848033}
   - {fileID: 5707609332688900495}
   m_Father: {fileID: 5707609332570812405}
-  m_RootOrder: 6
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!156049354 &5707609332229355862
 Grid:
@@ -1470,7 +1470,6 @@ Transform:
   - {fileID: 5707609332165570647}
   - {fileID: 5707609334011331170}
   - {fileID: 5707609333356513362}
-  - {fileID: 5707609334151854436}
   - {fileID: 5707609332286904657}
   - {fileID: 5707609332229355861}
   - {fileID: 5707609334130862773}
@@ -2560,7 +2559,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 5707609332570812405}
-  m_RootOrder: 8
+  m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &5707609333097506348
 MonoBehaviour:
@@ -3166,6 +3165,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _status: {fileID: 5707609333302362210}
   _move: {fileID: 0}
+  _underline: -4
 --- !u!114 &5707609333356513365
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -4299,7 +4299,7 @@ RectTransform:
   - {fileID: 5707609332592414548}
   - {fileID: 5707609333310602102}
   m_Father: {fileID: 5707609332570812405}
-  m_RootOrder: 7
+  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -4367,117 +4367,6 @@ MonoBehaviour:
   m_BlockingMask:
     serializedVersion: 2
     m_Bits: 4294967295
---- !u!1 &5707609334151854438
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 5707609334151854436}
-  - component: {fileID: 5707609334151854435}
-  - component: {fileID: 5707609334151854437}
-  m_Layer: 11
-  m_Name: UnderStageLine
-  m_TagString: GameOverCollider
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &5707609334151854436
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5707609334151854438}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: -6.5, z: 0}
-  m_LocalScale: {x: 100, y: 3, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 5707609332570812405}
-  m_RootOrder: 4
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!212 &5707609334151854435
-SpriteRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5707609334151854438}
-  m_Enabled: 0
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 0
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 0
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_Sprite: {fileID: 7482667652216324306, guid: 311925a002f4447b3a28927169b83ea6, type: 3}
-  m_Color: {r: 0.36078432, g: 0, b: 0, a: 1}
-  m_FlipX: 0
-  m_FlipY: 0
-  m_DrawMode: 0
-  m_Size: {x: 1, y: 1}
-  m_AdaptiveModeThreshold: 0.5
-  m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 1
-  m_MaskInteraction: 0
-  m_SpriteSortPoint: 0
---- !u!61 &5707609334151854437
-BoxCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5707609334151854438}
-  m_Enabled: 1
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IsTrigger: 1
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0}
-  m_SpriteTilingProperty:
-    border: {x: 0, y: 0, z: 0, w: 0}
-    pivot: {x: 0.5, y: 0.5}
-    oldSize: {x: 1, y: 1}
-    newSize: {x: 1, y: 1}
-    adaptiveTilingThreshold: 0.5
-    drawMode: 0
-    adaptiveTiling: 0
-  m_AutoTiling: 0
-  serializedVersion: 2
-  m_Size: {x: 1, y: 1}
-  m_EdgeRadius: 0
 --- !u!1001 &5707609333153463922
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -5019,7 +4908,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 1926922804203229419, guid: 8a1ecc4825039484fbde367b5de0a07c, type: 3}
       propertyPath: m_RootOrder
-      value: 5
+      value: 4
       objectReference: {fileID: 0}
     - target: {fileID: 1926922804203229419, guid: 8a1ecc4825039484fbde367b5de0a07c, type: 3}
       propertyPath: m_LocalPosition.x

--- a/Assets/Scripts/Play/MainRobot.cs
+++ b/Assets/Scripts/Play/MainRobot.cs
@@ -18,6 +18,7 @@ public class MainRobot : MonoBehaviour
     [HideInInspector] public ForceMove _move;
 
     private float _highScore = 0;   // 最高到達距離
+    [SerializeField] private float _underline;  // 超えたらゲームオーバーとなる基準高度
 
     private bool _isNotStart = false;        // 飛行し始めたタイミングを計るための、飛行していないかフラグ
     public bool IsNotStart { get { return _isNotStart; } private set { _isNotStart = value; } }
@@ -55,6 +56,12 @@ public class MainRobot : MonoBehaviour
             {
                 playPartsManager.IsUsingParts = false;
             }
+
+            // 高度によるゲームオーバー判定
+            if (transform.position.y <= _underline)
+            {
+                playSceneController.GameOver();
+            }
         }
         // 飛行し始め判定
         else if (IsNotStart &&  playSceneController.IsPlayingGame && _status.IsWaitingForFly && Input.GetKeyDown(KeyCode.Space))
@@ -62,16 +69,6 @@ public class MainRobot : MonoBehaviour
             IsNotStart = false;
             RobotStartMove();
             UsePartsByControl();
-        }
-
-        // ヒットストップデバッグ
-        if (Input.GetKeyDown(KeyCode.A))
-        {
-            PlaySceneController.Instance.RequestHitStopBySlow(0.25f, 1f);
-        }
-        else if(Input.GetKeyDown(KeyCode.S))
-        {
-            PlaySceneController.Instance.RequestHitStopByStop(1f);
         }
     }
 


### PR DESCRIPTION
#193 
MainRobotにゲームオーバーの基準高度の設定項目を追加し、操作している際はその高度を下回るとゲームオーバーになるようにした。
また、それに伴い下側にあった当たり判定を削除した。