### PR TITLE
Fix 299 change replay data to struct

### DIFF
--- a/Assets/Prefab/Play/PlaySystem.prefab
+++ b/Assets/Prefab/Play/PlaySystem.prefab
@@ -1876,18 +1876,6 @@ MonoBehaviour:
   CheckReplayEvent:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 5707609334011331171}
-        m_TargetAssemblyTypeName: ReplayInputManager, Assembly-CSharp
-        m_MethodName: SetNoMemoryMode
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
       - m_Target: {fileID: 8938645754938706309}
         m_TargetAssemblyTypeName: UIOpener, Assembly-CSharp
         m_MethodName: OpenPanel
@@ -4265,18 +4253,6 @@ MonoBehaviour:
       m_Calls:
       - m_Target: {fileID: 5707609333356513375}
         m_TargetAssemblyTypeName: PlayPartsManager, Assembly-CSharp
-        m_MethodName: GetParts
-        m_Mode: 0
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-      - m_Target: {fileID: 5707609333356513368}
-        m_TargetAssemblyTypeName: FollowerManager, Assembly-CSharp
         m_MethodName: GetParts
         m_Mode: 0
         m_Arguments:

--- a/Assets/Scripts/Play/Gimick/DropParts.cs
+++ b/Assets/Scripts/Play/Gimick/DropParts.cs
@@ -29,10 +29,13 @@ public class DropParts : GimickBase
     {
         if (!other.TryGetComponent(out MainRobot robot) || Picked) return;
         Picked = true;
-        // ロボットの重量を増やし、使用パーツリストの一番最後に獲得パーツを追加する
-        PlayPartsManager.Instance.GetParts(partsData, out PartsPerformance performance);
-        ForceMove move = robot._move;
-        move.SetWeight(move.GetWeight() + performance.m);
+        if (!PlaySceneController.Instance.IsReplayMode)
+        {
+            // ロボットの重量を増やし、使用パーツリストの一番最後に獲得パーツを追加する
+            PlayPartsManager.Instance.GetParts(partsData, out PartsPerformance performance);
+            ForceMove move = robot._move;
+            move.SetWeight(move.GetWeight() + performance.m);
+        }
 
         // 自身を無効化する
         gameObject.SetActive(false);

--- a/Assets/Scripts/Play/MainRobot.cs
+++ b/Assets/Scripts/Play/MainRobot.cs
@@ -17,16 +17,16 @@ public class MainRobot : MonoBehaviour
     public RobotStatus _status;
     [HideInInspector] public ForceMove _move;
 
-    private float _highScore = 0;   // 最高到達距離
+    private ReplayData _useReplayData;  // リプレイ再生時に用いるデータ
+    private float _highScore = 0;       // 最高到達距離
     [SerializeField] private float _underline;  // 超えたらゲームオーバーとなる基準高度
 
     [SerializeField] private ParticleSystem _gameoverPerticle;
 
-    private bool _isNotStart = false;        // 飛行し始めたタイミングを計るための、飛行していないかフラグ
-    public bool IsNotStart { get { return _isNotStart; } private set { _isNotStart = value; } }
-    private bool IsUsePartsInForce = false; // アイテムを強制的に使用するかのフラグ（リプレイなどで整合性が崩れないように）
-    private bool ReplayMode = false;        // リプレイ操作に移るかのフラグ
-    private ReplayData _useReplayData;
+    // シーン判定
+    private bool IsWaitForControl => playSceneController ? playSceneController.IsWaitingForRobot && !playSceneController.IsReplayMode : false;
+    private bool IsControlMode => playSceneController ? playSceneController.IsRobotStartMove && !playSceneController.IsReplayMode : false;
+    private bool IsReplayMode => playSceneController ? playSceneController.IsReplayMode : throw new NullReferenceException("PlaySceneControllerのAwake処理前にInstanceを参照しました");
 
     private void Awake()
     {
@@ -38,8 +38,8 @@ public class MainRobot : MonoBehaviour
     // Update is called once per frame
     private void Update()
     {
-        // 飛行中の処理
-        if (_status.IsFlying && !_player.IsPlaying)
+        // 飛行中の操作モード時処理
+        if (IsControlMode)
         {
             // アイテム使用終了判定
             if (_status.IsUsingParts && !playPartsManager.IsUsingParts)
@@ -47,13 +47,12 @@ public class MainRobot : MonoBehaviour
                 endUseParts();
             }
 
-            // 仮の操作処理（アイテム使用）
+            // アイテム使用キーの入力受付
             if (Input.GetKeyDown(KeyCode.Space))
             {
-                Debug.Log("アイテム使用ボタンを押した");
                 UsePartsByControl();
             }
-            // アイテムの手動パージ
+            // アイテムの手動パージ処理
             if (playPartsManager.IsUsingParts && Input.GetKeyDown(KeyCode.R))
             {
                 playPartsManager.IsUsingParts = false;
@@ -66,9 +65,8 @@ public class MainRobot : MonoBehaviour
             }
         }
         // 飛行し始め判定
-        else if (IsNotStart &&  playSceneController.IsPlayingGame && _status.IsWaitingForFly && Input.GetKeyDown(KeyCode.Space))
+        else if (IsWaitForControl && partsInfo.HasNext && Input.GetKeyDown(KeyCode.Space))
         {
-            IsNotStart = false;
             RobotStartMove();
             UsePartsByControl();
         }
@@ -77,7 +75,7 @@ public class MainRobot : MonoBehaviour
     private void FixedUpdate()
     {
         // 最高到達距離を確認する
-        if (_status.IsFlying && !_player.IsPlaying && transform.position.x > _highScore)
+        if (IsControlMode && transform.position.x > _highScore)
         {
             _highScore = transform.position.x;
             playSceneController.Score = _highScore;
@@ -96,28 +94,24 @@ public class MainRobot : MonoBehaviour
         playSceneController = PlaySceneController.Instance;
         playPartsManager = PlayPartsManager.Instance;
 
-        if (ReplayMode)
+        if (IsReplayMode)
         {
             // リプレイの初期設定
             if (_useReplayData == null) throw new Exception("リプレイ用のデータが設定されていません。");
             _player.LoadReplayData(_useReplayData);
 
             // 用意してきたパーツをリプレイのものに変更
-            partsInfo.partsList = new List<PartsInfo.PartsData>(_player.InitialPartsDatas);
+            partsInfo.partsList = _player.InitialPartsDatas;
 
             // スコアをリプレイのものに変更
             playSceneController.Score = _useReplayData.score;
 
-            // リプレイ用の処理モードに変更
-            IsUsePartsInForce = true;
-            IsNotStart = false;
+            // リプレイ時は1秒後に動き始める
             Invoke("RobotStartMove", 1f);
         }
         else
         {
-            // 操作する際の処理
-            IsUsePartsInForce = false;
-            IsNotStart = true;  // まだ飛行を開始していないフラグをtrueにする
+            // リプレイ時に使用するデータを初期化する
             _useReplayData = null;
         }
     }
@@ -131,7 +125,7 @@ public class MainRobot : MonoBehaviour
         // 状態を変化させる
         _status.startGame();
 
-        // ロボットが動き始めた際のイベントを呼ぶ
+        // ロボットが動き始めた際の処理状態に移る
         playSceneController.RobotStartMove();
         if (_player.IsLoaded) _player.StartReplay();
     }
@@ -140,7 +134,7 @@ public class MainRobot : MonoBehaviour
     [ContextMenu("Debug/UseParts")]
     private void UsePartsByControl()
     {
-        if (_player.IsPlaying) return;
+        if (playSceneController.IsReplayMode) return;
         else if (!partsInfo.HasNext) return;
         else if (!_status.IsPartsUsable) return;
         playPartsManager.UseParts(out PartsPerformance performance, out PartsInfo.PartsData data, out IForce force);
@@ -149,7 +143,7 @@ public class MainRobot : MonoBehaviour
     // リプレイによってアイテムを使用する処理
     public void UsePartsByReplay(PartsInfo.PartsData data)
     {
-        if (!_player.IsPlaying) return;
+        if (!playSceneController.IsReplayMode) return;
         playPartsManager.UseParts(out PartsPerformance performance, out _, out _);
         UseParts(data, performance);
     }
@@ -163,9 +157,9 @@ public class MainRobot : MonoBehaviour
             return;
         }
         // アイテムが使用できない状態のとき
-        else if (!_status.IsPartsUsable && IsUsePartsInForce)
+        else if (!_status.IsPartsUsable && IsReplayMode)
         {
-            // アイテムを使用できる状態に強制的に移行する
+            // リプレイ時はアイテムを使用できる状態に強制的に移行する
             if (_status.IsUsingParts) _status.endUseParts();
             _status.endCooltime();
         }
@@ -185,22 +179,25 @@ public class MainRobot : MonoBehaviour
             summonned.Summon(data, _transform);
             if (summonned.IsDestroyWithParts)
             {
+                // 設定がオンであれば、パーツとともに破棄されるように登録する
                 _status.RegisterObjectAsDestroyWithParts(summonned.gameObject);
             }
         }
+
+        Debug.Log("(MainRobot)パーツを使用しました：ID = " + data.id);
     }
     // パーツの使用が終わった際の処理
     public void endUseParts()
     {
         PartsInfo.Instance.RemoveParts();   // パーツをリストから削除する
         _status.endUseParts();
+        Debug.Log("(MainRobot)パーツの使用を終了しました");
     }
 
 
     // ゲームクリア時の処理
     public void GameClear()
     {
-        ReplayMode = false;
         // 力を無くし、成功アニメーション処理に遷移する
         _move.ZeroForce();
         _status.GameClear();
@@ -209,7 +206,6 @@ public class MainRobot : MonoBehaviour
     // ゲームオーバー時の処理
     public void GameOver()
     {
-        ReplayMode = false;
         // 失敗アニメーション処理に遷移する
         _move.ZeroForce();
         _status.GameOver();
@@ -225,15 +221,15 @@ public class MainRobot : MonoBehaviour
     // カスタムメニューを開いたときの処理
     public void OpenCustomMenu()
     {
-        // 飛行中に呼び出されたなら、クレーンで持ち上げられるアニメーションを入れる
-        if (_status.IsFlying)
+        // 飛行中に呼び出されたなら、ゲームオーバー時の爆破処理を呼ぶ
+        if (playSceneController ? playSceneController.IsRobotStartMove : false)
         {
-            GameOver(); // ゲームオーバー時の爆発処理を呼ぶ
+            GameOver();
         }
-        // （ゲームオーバー後に呼び出されたなら、既に非表示なので何もしない）
+        // （ゲーム終了後に呼び出されたなら何もしない）
     }
 
-    // リセットするときの処理
+    // スタート地点に戻り、状態をリセットする
     public void ResetToStart()
     {
         _highScore = 0;
@@ -244,13 +240,12 @@ public class MainRobot : MonoBehaviour
     }
 
     // リプレイを再生する際の準備
-    public void SetReplayMode()
+    public void SetReplayData()
     {
-        ReplayMode = true;
         if (_useReplayData == null)
         {
             // リプレイデータが空なら、現在のリプレイデータを取得する
-            _useReplayData = new ReplayData(ReplayInputManager.Instance.Data);
+            _useReplayData = ReplayInputManager.Instance.Data;
         }
     }
 
@@ -258,7 +253,7 @@ public class MainRobot : MonoBehaviour
     // ゲームオーバーとなる当たり判定との衝突判定を担うメソッド
     public void CheckGameOverCollision(Collider2D other)
     {
-        if (!_player.IsPlaying && _status.IsFlying && other.CompareTag(GameOverColliderTag))
+        if (IsControlMode && other.CompareTag(GameOverColliderTag))
         {
             if (other.TryGetComponent(out GameOverSE gameoverSE))
             {
@@ -268,7 +263,7 @@ public class MainRobot : MonoBehaviour
             PlaySceneController.Instance.GameOver();
         }
     }
-    // リプレイに自分の位置と速度情報を格納する
+    // リプレイ用に自分の位置と速度情報を返答する
     public void GetTransform(out Vector2 position, out Vector2 velocity)
     {
         position = transform.position;

--- a/Assets/Scripts/Play/MainRobot.cs
+++ b/Assets/Scripts/Play/MainRobot.cs
@@ -25,7 +25,7 @@ public class MainRobot : MonoBehaviour
 
     // シーン判定
     private bool IsWaitForControl => playSceneController ? playSceneController.IsWaitingForRobot && !playSceneController.IsReplayMode : false;
-    private bool IsControlMode => playSceneController ? playSceneController.IsRobotStartMove && !playSceneController.IsReplayMode : false;
+    private bool IsControlMode => playSceneController ? playSceneController.IsRobotStartMove && playSceneController.IsPlayingGame && !playSceneController.IsReplayMode : false;
     private bool IsReplayMode => playSceneController ? playSceneController.IsReplayMode : throw new NullReferenceException("PlaySceneControllerのAwake処理前にInstanceを参照しました");
 
     private void Awake()
@@ -222,7 +222,7 @@ public class MainRobot : MonoBehaviour
     public void OpenCustomMenu()
     {
         // 飛行中に呼び出されたなら、ゲームオーバー時の爆破処理を呼ぶ
-        if (playSceneController ? playSceneController.IsRobotStartMove : false)
+        if (playSceneController ? playSceneController.IsRobotStartMove && _status.IsFlying : false)
         {
             GameOver();
         }

--- a/Assets/Scripts/Play/PlayPartsManager.cs
+++ b/Assets/Scripts/Play/PlayPartsManager.cs
@@ -68,6 +68,8 @@ public class PlayPartsManager : SingletonMonoBehaviourInSceneBase<PlayPartsManag
         partsInfo.AddParts(data);
         performance = partsPerformanceData.getData(data.id);
         getPartsEvent.Invoke(data);
+
+        Debug.Log("パーツを獲得しました：ID = " + data.id);
     }
     public void GetParts(PartsInfo.PartsData data)
     {
@@ -92,5 +94,7 @@ public class PlayPartsManager : SingletonMonoBehaviourInSceneBase<PlayPartsManag
         IsUsingParts = false;
         partsInfo.Reset();
         partsInfo = PartsInfo.Instance;
+
+        Debug.Log("カスタムパーツデータを保存時の状態にリセットしました");
     }
 }

--- a/Assets/Scripts/Play/PlaySceneController.cs
+++ b/Assets/Scripts/Play/PlaySceneController.cs
@@ -15,7 +15,7 @@ public class PlaySceneController : SingletonMonoBehaviourInSceneBase<PlaySceneCo
     public bool IsPlayingGame => scene == E_PlayScene.GamePlay; // ゲームプレイ中か判定
     public bool IsOpenableCustomMenu => scene == E_PlayScene.GamePlay || scene == E_PlayScene.GameEnd;  // カスタムメニューを開けるか判定
     public bool IsWaitingForRobot => IsPlayingGame && !_isRobotStartMove;   // ゲーム開始後、ロボットの動き始めを待っている状態か判定
-    public bool IsRobotStartMove => IsPlayingGame && _isRobotStartMove;     // ゲーム開始後、ロボットが動き始めたか判定
+    public bool IsRobotStartMove => _isRobotStartMove;          // ゲーム開始後、ロボットが動き始めたか判定
     private bool _isRobotStartMove;
     public bool IsReplayMode => _isReplayMode;  // リプレイ再生モードか判定
     private bool _isReplayMode;
@@ -142,7 +142,7 @@ public class PlaySceneController : SingletonMonoBehaviourInSceneBase<PlaySceneCo
         {
             // ゲームのプレイ中か判定
             bool IsPlayingGame = this.IsPlayingGame;
-            bool IsRobotStartMove = this.IsRobotStartMove;
+            bool IsRobotStartMove = this.IsRobotStartMove && IsPlayingGame;
             scene = E_PlayScene.CustomMenu;
 
             // 飛行中なら、ロボットを連れていってカスタムメニューを開く処理に移る

--- a/Assets/Scripts/Play/PlaySceneController.cs
+++ b/Assets/Scripts/Play/PlaySceneController.cs
@@ -17,6 +17,8 @@ public class PlaySceneController : SingletonMonoBehaviourInSceneBase<PlaySceneCo
     public bool IsWaitingForRobot => IsPlayingGame && !_isRobotStartMove;   // ゲーム開始後、ロボットの動き始めを待っている状態か判定
     public bool IsRobotStartMove => IsPlayingGame && _isRobotStartMove;     // ゲーム開始後、ロボットが動き始めたか判定
     private bool _isRobotStartMove;
+    public bool IsReplayMode => _isReplayMode;  // リプレイ再生モードか判定
+    private bool _isReplayMode;
 
     [SerializeField] private CameraController cam;
     [SerializeField] private MainRobot robot;
@@ -99,6 +101,8 @@ public class PlaySceneController : SingletonMonoBehaviourInSceneBase<PlaySceneCo
 
             // 開始アニメーション処理を呼び出す
             startAnimationEvent.Invoke();
+
+            Debug.Log("処理遷移：スタートアニメーション開始");
         }
     }
     // ゲームが開始した際に呼び出されるメソッド
@@ -115,6 +119,8 @@ public class PlaySceneController : SingletonMonoBehaviourInSceneBase<PlaySceneCo
 
             // 開始時のイベントを呼び出す
             startGameEvent.Invoke();
+
+            Debug.Log("処理遷移：ゲーム開始");
         }
     }
     // ロボットが動き始めた際に呼び出されるメソッド
@@ -124,6 +130,8 @@ public class PlaySceneController : SingletonMonoBehaviourInSceneBase<PlaySceneCo
         {
             _isRobotStartMove = true;
             startRobotMove.Invoke();
+
+            Debug.Log("処理遷移：ロボット移動開始");
         }
     }
     // カスタムメニューを開く
@@ -133,13 +141,14 @@ public class PlaySceneController : SingletonMonoBehaviourInSceneBase<PlaySceneCo
         if (IsOpenableCustomMenu)
         {
             // ゲームのプレイ中か判定
-            bool IsNeedSetResult = scene == E_PlayScene.GamePlay;
+            bool IsPlayingGame = this.IsPlayingGame;
+            bool IsRobotStartMove = this.IsRobotStartMove;
             scene = E_PlayScene.CustomMenu;
 
             // 飛行中なら、ロボットを連れていってカスタムメニューを開く処理に移る
             cam.IsFollowRobot = false;
             robot.OpenCustomMenu();
-            if (IsNeedSetResult)
+            if (IsPlayingGame)
             {
                 endGameEvent.Invoke();
                 if (IsRobotStartMove) OpenCustomWhenPlayEvent.Invoke();
@@ -147,13 +156,15 @@ public class PlaySceneController : SingletonMonoBehaviourInSceneBase<PlaySceneCo
 
             // カスタムメニューのオープン処理
             PartsInfo.Instance.Reset(); // パーツの状態をカスタム時に戻す
-            if (IsNeedSetResult && !robot.IsNotStart) {
+            if (IsRobotStartMove) {
                 CallMethodAfterDuration(OpenCustomMenuEvent.Invoke, OpenCustomWhenPlayDuration);
             }
             else
             {
                 OpenCustomMenuEvent.Invoke();
             }
+
+            Debug.Log("処理遷移：カスタムメニューを開く");
         }
     }
     // カスタムメニューを閉じたときの処理
@@ -164,6 +175,10 @@ public class PlaySceneController : SingletonMonoBehaviourInSceneBase<PlaySceneCo
         {
             scene = E_PlayScene.FirstCameraMove;
             NoReplayRetryEvent.Invoke();
+
+            Debug.Log("処理遷移：カスタムメニューを閉じた");
+
+            _isReplayMode = false;
             RetryReady();
         }
     }
@@ -182,6 +197,8 @@ public class PlaySceneController : SingletonMonoBehaviourInSceneBase<PlaySceneCo
             endGameEvent.Invoke();
 
             gameClearEvent.Invoke();
+
+            Debug.Log("処理遷移：ゲームクリア");
         }
     }
     // ゲームオーバー処理を行う
@@ -200,6 +217,8 @@ public class PlaySceneController : SingletonMonoBehaviourInSceneBase<PlaySceneCo
             
             // ロボットパージアニメーション待機後に、結果表示をするなどの処理を呼ぶ
             gameOverEvent.Invoke();
+
+            Debug.Log("処理遷移：ゲームオーバー");
         }
     }
     // 現在のプレイをリプレイで確認する
@@ -212,7 +231,11 @@ public class PlaySceneController : SingletonMonoBehaviourInSceneBase<PlaySceneCo
 
             // ロボットをリプレイモードに設定する
             CheckReplayEvent.Invoke();
-            robot.SetReplayMode();
+            robot.SetReplayData();
+
+            Debug.Log("処理遷移：リプレイ確認");
+
+            _isReplayMode = true;
             RetryReady();
         }
     }
@@ -223,6 +246,10 @@ public class PlaySceneController : SingletonMonoBehaviourInSceneBase<PlaySceneCo
         {
             scene = E_PlayScene.FirstCameraMove;
             NoReplayRetryEvent.Invoke();
+
+            Debug.Log("処理遷移：そのままリトライ");
+
+            _isReplayMode = false;
             RetryReady();
         }
     }
@@ -233,6 +260,8 @@ public class PlaySceneController : SingletonMonoBehaviourInSceneBase<PlaySceneCo
         // ステージをリセットし、最初からやり直す
         ResetStage();
         RetryEvent.Invoke();
+
+        Debug.Log("処理遷移：リトライ準備処理");
 
         // 処理時間を待ってから次の処理を呼び出す
         Action startNextTry = () =>

--- a/Assets/Scripts/Play/Replay/ReplayInputManager.cs
+++ b/Assets/Scripts/Play/Replay/ReplayInputManager.cs
@@ -7,7 +7,7 @@ public class ReplayInputManager : SingletonMonoBehaviourInSceneBase<ReplayInputM
 {
     // 現在のプレイのリプレイデータ
     [SerializeField] private ReplayData _data = new ReplayData();
-    public ReplayData Data => _data;
+    public ReplayData Data => new ReplayData(_data);
     [SerializeField] private int TransformUpdateFrame = 50; // 位置情報を更新する間隔（FixedUpdate単位でのフレーム）
     private int frameCnt = -1;
     public float TimeSec => _data.finishFrame * Time.fixedDeltaTime;
@@ -15,7 +15,7 @@ public class ReplayInputManager : SingletonMonoBehaviourInSceneBase<ReplayInputM
     private PlaySceneController _sceneController;
     [SerializeField] private MainRobot robot;
 
-    private bool NoMemoryMode = false;
+    private bool NoMemoryMode;
     private bool IsGamePlay = false;
 
     private void FixedUpdate()
@@ -23,16 +23,11 @@ public class ReplayInputManager : SingletonMonoBehaviourInSceneBase<ReplayInputM
         if (IsGamePlay) frameCnt++;
     }
 
-    // リプレイデータを保存せず、現在あるデータをそのままにする状態にする
-    public void SetNoMemoryMode()
-    {
-        if (IsGamePlay) return;
-        NoMemoryMode = true;
-    }
     // データの初期化（シーン管理でゲームを開始したと同時に呼び出され、使用パーツ情報が初期化される）
     public void Ready()
     {
         _sceneController = PlaySceneController.Instance;
+        NoMemoryMode = _sceneController.IsReplayMode;
         if (NoMemoryMode) return;
         _data.ReadyPartsInfo(_sceneController.StageNum);
     }
@@ -79,7 +74,6 @@ public class ReplayInputManager : SingletonMonoBehaviourInSceneBase<ReplayInputM
             PlaySceneController.Instance.SaveProgress();
         }
         IsGamePlay = false;
-        NoMemoryMode = false;
     }
     // リプレイデータを保存する
     [ContextMenu("Debug/Save")]
@@ -89,6 +83,7 @@ public class ReplayInputManager : SingletonMonoBehaviourInSceneBase<ReplayInputM
         ReplayDatas datas = ReplayDatas.Instance;
         datas.RegisterData(_data);
         datas.Save();
+        Debug.Log("リプレイデータを保存しました");
     }
 
     // 定期的にロボット位置を記録する

--- a/Assets/Scripts/Play/Replay/ReplayInputManager.cs
+++ b/Assets/Scripts/Play/Replay/ReplayInputManager.cs
@@ -66,7 +66,8 @@ public class ReplayInputManager : SingletonMonoBehaviourInSceneBase<ReplayInputM
     // ゲーム結果を記録（ゲームが終了した際に記録）
     public void SetResult()
     {
-        if (!NoMemoryMode && !PlaySceneController.Instance.IsWaitingForRobot)
+        PlaySceneController _playSceneController = PlaySceneController.Instance;
+        if (_playSceneController.IsRobotStartMove && !_playSceneController.IsReplayMode)
         {
             // リプレイモードではなく、ロボットが動き始めていた時は、取得したデータを自動で保存させてみる
             _data.RegisterResult(frameCnt, _sceneController.Score);

--- a/Assets/Scripts/Play/Replay/ShadowManager.cs
+++ b/Assets/Scripts/Play/Replay/ShadowManager.cs
@@ -11,6 +11,7 @@ public class ShadowManager : SingletonMonoBehaviourInSceneBase<ShadowManager>
 
     // シーン上にあるシャドウロボットオブジェクトのリスト
     private bool IsStart = false;
+    private List<ReplayData> _useReplayDatas = new List<ReplayData>();
     private List<ShadowRobot> shadows = new List<ShadowRobot>();
 
 
@@ -20,8 +21,15 @@ public class ShadowManager : SingletonMonoBehaviourInSceneBase<ShadowManager>
     {
         if (IsStart) return;
 
+        // リプレイモードでは無いとき、シャドウに用いるリプレイデータを更新する
+        if (!PlaySceneController.Instance.IsReplayMode)
+        {
+            // このステージのリプレイデータを全てシャドウにする
+            _useReplayDatas = new List<ReplayData>(StageReplayDatas);
+        }
+
         // このステージのリプレイデータを全てシャドウにする
-        foreach (var replayData in StageReplayDatas)
+        foreach (var replayData in _useReplayDatas)
         {
             var shadow = Instantiate(shadowPrefab, firstPosition, Quaternion.identity);
             shadow.LoadReplayData(replayData);

--- a/Assets/Scripts/Play/RobotStatus.cs
+++ b/Assets/Scripts/Play/RobotStatus.cs
@@ -20,7 +20,7 @@ public class RobotStatus : MonoBehaviour
     private E_RobotStatus _status = E_RobotStatus.Ready;
     private int cooltime = 0;       // クールタイム
 
-    private Sprite usingPartsSprite = null;
+    private Sprite usingPartsSprite = null; // 生成している使用中パージスプライトの参照
 
     // ロボットの状態判定メソッド
     public bool IsWaitingForFly => _status == E_RobotStatus.Ready;  // 飛行未開始判定
@@ -30,6 +30,7 @@ public class RobotStatus : MonoBehaviour
     public bool IsEndFly => _status == E_RobotStatus.EndFly;    // 飛行終了判定
 
 
+    // キャッシュ等
     [SerializeField] private Collider2D bodyCollider;
     [SerializeField] private Animator _animator;
     [SerializeField] private AudioSource _usePartsAudioSource;
@@ -45,13 +46,14 @@ public class RobotStatus : MonoBehaviour
     [Header("装備パーツ情報")]
     [SerializeField] private SpriteRenderer _partsPrefab;
     private SpriteRenderer _partsObject;
-    [SerializeField] private Vector2 _propellerLocate = Vector2.zero;
-    [SerializeField] private Vector2 _rocketLocate = Vector2.zero;
-    [SerializeField] private Vector2 _gliderLocate = Vector2.zero;
+    [SerializeField] private Vector2 _propellerLocate = Vector2.zero;   // プロペラの出現位置
+    [SerializeField] private Vector2 _rocketLocate = Vector2.zero;      // ロケットの出現位置
+    [SerializeField] private Vector2 _gliderLocate = Vector2.zero;      // グライダーの出現位置
 
-    [SerializeField] private float _bombExplodeDistance = 0f;
-    [SerializeField] private ParticleSystem _explodesPrefab;
+    [SerializeField] private float _bombExplodeDistance = 0f;   // 爆発の出現距離
+    [SerializeField] private ParticleSystem _explodesPrefab;    // 爆発エフェクトのPrefab
 
+    // パーツの使用終了とともに破棄するオブジェクトのリスト
     private List<GameObject> _destroyWithPartsObjects = new List<GameObject>();
 
     [Header("イベント系統")]
@@ -233,7 +235,7 @@ public class RobotStatus : MonoBehaviour
         }
         _status = E_RobotStatus.EndFly;
 
-        // TODO：ゲーム失敗時のアニメーションなどのロボット関係の処理
+        // ゲーム失敗時のアニメーションなどのロボット関係の処理
         _purgeManager.AddPartsBySprite(GameOverRobotPurgeData);
         if (_partsObject)
         {

--- a/Assets/Scripts/Play/Values/ReplayData.cs
+++ b/Assets/Scripts/Play/Values/ReplayData.cs
@@ -124,7 +124,7 @@ public class ReplayData
 
     // ロボットの位置情報を格納するクラス
     [Serializable]
-    public class LocateData
+    public struct LocateData
     {
         public int frame;   // 経過フレーム数
         public Vector2 position;    // 座標
@@ -138,7 +138,7 @@ public class ReplayData
     }
     // 加わった力を記録するクラス
     [Serializable]
-    public class ForceData
+    public struct ForceData
     {
         public int frame;   // 経過フレーム数
         public PartsPerformance.E_ForceType forceType;
@@ -184,7 +184,7 @@ public class ReplayData
     }
     // 獲得したパーツデータを格納するクラス
     [Serializable]
-    public class GetPartsData
+    public struct GetPartsData
     {
         public int frame;
         public PartsPerformance.E_PartsID id;

--- a/Assets/Scripts/Play/Values/ReplayDatas.cs
+++ b/Assets/Scripts/Play/Values/ReplayDatas.cs
@@ -11,7 +11,7 @@ public class ReplayDatas : SavableSingletonBase<ReplayDatas>
     public List<ReplayData> datas = new List<ReplayData>();
     public List<ReplayData> GetDatas() => datas;
     public int Length => datas.Count;
-    public ReplayData GetData(int index) => datas[index];
+    public ReplayData GetData(int index) => new ReplayData(datas[index]);
 
     // リプレイデータを追加する
     public void RegisterData(ReplayData data)
@@ -31,6 +31,7 @@ public class ReplayDatas : SavableSingletonBase<ReplayDatas>
     public ReplayData GetHighScoreReplay(int StageNum)
     {
         var dataList = GetStageReplay(StageNum);
+        if (!(dataList?.Count > 0)) return null;
         ReplayData highscore = dataList[0];
         for(int i = 1; i < dataList.Count; i++)
         {


### PR DESCRIPTION
リプレイデータの内部をstructで管理。
リプレイ状態であることを管理する場所をPlaySceneControllerに移行。

リプレイデータでのアイテム増殖バグを修正（ドロップアイテムがリプレイデータでもアイテム追加してた）。
ロボットが動いていないとき、リプレイデータを保存しないようにした（PlaySceneControllerから状態判定）。