### PR TITLE
リプレイ時ドロップパーツを獲得した際に重量が増えるように修正した

### DIFF
--- a/Assets/Prefab/Play/PlaySystem.prefab
+++ b/Assets/Prefab/Play/PlaySystem.prefab
@@ -4263,6 +4263,18 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
+      - m_Target: {fileID: 5707609333356513365}
+        m_TargetAssemblyTypeName: ForceMove, Assembly-CSharp
+        m_MethodName: AddWeightByPartsData
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
   endReplayEvent:
     m_PersistentCalls:
       m_Calls:

--- a/Assets/Scripts/Play/ForceMove.cs
+++ b/Assets/Scripts/Play/ForceMove.cs
@@ -88,10 +88,10 @@ public class ForceMove : MonoBehaviour
     }
 
     // 重量を設定する（初期重量の設定用。アイテムを使用した後は自動で重量が減っていく）
-    public void SetWeight(float mass) {
-        rb.mass = mass;
-    }
+    public void SetWeight(float mass) => rb.mass = mass;
     public float GetWeight() => rb.mass;
+    public void AddWeightByPartsData(PartsInfo.PartsData data) => rb.mass += PlayPartsManager.Instance.GetPerformance(data.id).m;
+    public void AddWeightByPartsPerformance(PartsPerformance performance) => rb.mass += performance.m;
     public Vector2 GetVelocity() => rb.velocity;
 
     // 加える合力の計算

--- a/Assets/Scripts/Play/Gimick/DropParts.cs
+++ b/Assets/Scripts/Play/Gimick/DropParts.cs
@@ -34,7 +34,7 @@ public class DropParts : GimickBase
             // ロボットの重量を増やし、使用パーツリストの一番最後に獲得パーツを追加する
             PlayPartsManager.Instance.GetParts(partsData, out PartsPerformance performance);
             ForceMove move = robot._move;
-            move.SetWeight(move.GetWeight() + performance.m);
+            move.AddWeightByPartsPerformance(performance);
         }
 
         // 自身を無効化する

--- a/Assets/Scripts/Play/Replay/ShadowRobot.cs
+++ b/Assets/Scripts/Play/Replay/ShadowRobot.cs
@@ -77,10 +77,10 @@ public class ShadowRobot : MonoBehaviour
     public void AddGettingPartsWeight(PartsInfo.PartsData data)
     {
         // 獲得したパーツの重量を取得する
-        float weight = _playPartsManager.GetPerformance(data.id).m;
+        var performance = _playPartsManager.GetPerformance(data.id);
 
         // ロボットの重量を更新する
-        _move.SetWeight(_move.GetWeight() + weight);
+        _move.AddWeightByPartsPerformance(performance);
     }
 
     // リプレイ終了時の処理


### PR DESCRIPTION
リプレイで誤差が生じる原因について、ドロップパーツを獲得した際にメインロボットの重量が増えていなかった事が発覚したので、重量が増えるように修正いたしました。