### PR TITLE
ロボットの接地判定を修正

### DIFF
--- a/Assets/Prefab/Play/PlaySystem.prefab
+++ b/Assets/Prefab/Play/PlaySystem.prefab
@@ -2229,6 +2229,7 @@ MonoBehaviour:
   soundBeeps:
   - {fileID: 5365767623787590517}
   - {fileID: 8710792164603782712}
+  _mainRobot: {fileID: 5707609333356513361}
 --- !u!114 &108143105667539340
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Play/Gimick/CrashableObject.cs
+++ b/Assets/Scripts/Play/Gimick/CrashableObject.cs
@@ -56,6 +56,11 @@ public class CrashableObject : GimickBase
 
         // 当たり判定を無効化
         _collider.enabled = false;
+        if (gameObject.layer == LayerMask.NameToLayer("StageWall"))
+        {
+            // 地面の当たり判定を無効化する際はロボットの接地判定をリセットする
+            GimickManager.Instance.ResetOnGround();
+        }
 
         // 自身を破棄する
         _crashEvent.Invoke();

--- a/Assets/Scripts/Play/Gimick/GimickManager.cs
+++ b/Assets/Scripts/Play/Gimick/GimickManager.cs
@@ -9,6 +9,8 @@ public class GimickManager : SingletonMonoBehaviourInSceneBase<GimickManager>
 
     [SerializeField] private List<SoundBeep> soundBeeps = new List<SoundBeep>();
 
+    [SerializeField] private MainRobot _mainRobot;
+
     // ギミックを管理リストに追加する
     public void SaveGimick(GimickBase gimick)
     {
@@ -56,5 +58,12 @@ public class GimickManager : SingletonMonoBehaviourInSceneBase<GimickManager>
             return;
         }
         soundBeeps[index].Beep();
+    }
+
+    // 地面の当たり判定がDestroy等で消えた際はOnTriggerExitが反応しないので、AnimatorのOnGround（接地判定）をリセットする。
+    public void ResetOnGround()
+    {
+        _mainRobot._status.SetOnGround(false);
+        ShadowManager.Instance.ResetOnGround();
     }
 }

--- a/Assets/Scripts/Play/Replay/ShadowManager.cs
+++ b/Assets/Scripts/Play/Replay/ShadowManager.cs
@@ -68,6 +68,14 @@ public class ShadowManager : SingletonMonoBehaviourInSceneBase<ShadowManager>
     }
 
 
+    public void ResetOnGround()
+    {
+        foreach(var shadow in shadows)
+        {
+            shadow?.ResetOnGround();
+        }
+    }
+
     // シャドウに使用するリプレイデータを選択する
     private List<ReplayData> StageReplayDatas => ReplayDatas.Instance.GetStageReplay(PlaySceneController.Instance.StageNum);
 }

--- a/Assets/Scripts/Play/Replay/ShadowRobot.cs
+++ b/Assets/Scripts/Play/Replay/ShadowRobot.cs
@@ -98,4 +98,5 @@ public class ShadowRobot : MonoBehaviour
     {
         _move.SetWeight(_player.GetInitialWeight(_playPartsManager));
     }
+    public void ResetOnGround() => _status.SetOnGround(false);
 }


### PR DESCRIPTION
破壊可能ギミックを破壊した際、地面の当たり判定が無効化される場合にOnTriggerExitが呼び出されないので、地面にいるままの判定になっていた。
そのため、該当する判定を無効化する際にメインロボットとシャドウの接地判定をリセットするようにした。